### PR TITLE
use existing keyfile on init

### DIFF
--- a/cli/di.container.ts
+++ b/cli/di.container.ts
@@ -1,3 +1,5 @@
+import os from 'os'
+import { join } from "path"
 import { asClass, asFunction, asValue, createContainer, InjectionMode } from "awilix"
 import Web3 from 'web3'
 import shell from 'shelljs'
@@ -19,10 +21,10 @@ import { provideRunTransactionHandlersOnBlock } from "./utils/run.transaction.ha
 import { provideRunTransactionHandlersOnTransaction } from "./utils/run.transaction.handlers.on.transaction"
 import { provideGetAgentHandlers } from "./utils/get.agent.handlers"
 import { provideGetKeyfile } from "./utils/get.keyfile"
-import { provideCreateNewKeyfile } from "./utils/create.new.keyfile"
+import { provideCreateKeyfile } from "./utils/create.keyfile"
 import { FortaConfig } from "."
 
-const FORTA_KEYSTORE = ".forta"
+const FORTA_KEYSTORE = join(os.homedir(), ".forta")
 const FORTA_CONFIG_FILENAME = "forta.config.json"
 
 export default function configureContainer() {
@@ -54,7 +56,7 @@ export default function configureContainer() {
     runTransactionHandlersOnTransaction: asFunction(provideRunTransactionHandlersOnTransaction),
     getJsonFile: asValue(getJsonFile),
     getKeyfile: asFunction(provideGetKeyfile),
-    createNewKeyfile: asFunction(provideCreateNewKeyfile),
+    createKeyfile: asFunction(provideCreateKeyfile),
 
     fortaKeystore: asValue(FORTA_KEYSTORE),
     fortaConfig: asFunction(() => {

--- a/cli/utils/create.keyfile.ts
+++ b/cli/utils/create.keyfile.ts
@@ -1,21 +1,22 @@
 import fs from 'fs'
 import shelljs from 'shelljs'
-import { assertExists } from '.'
+import { assertExists, assertShellResult } from '.'
 var keythereum = require("keythereum");
 
-// creates a new keyfile in keystore folder (which is created if needed) encrypted using password
-export type CreateNewKeyfile = (password: string) => Promise<{ publicKey: string, privateKey: string}>
+// creates a keyfile in keystore folder (which is created if needed) encrypted using password
+export type CreateKeyfile = (password: string) => Promise<{ publicKey: string, privateKey: string}>
 
-export function provideCreateNewKeyfile(
+export function provideCreateKeyfile(
   shell: typeof shelljs,
   fortaKeystore: string
-): CreateNewKeyfile {
+): CreateKeyfile {
   assertExists(shell, 'shell')
   assertExists(fortaKeystore, 'fortaKeystore')
 
-  return async function createNewKeyfile(password: string) {
+  return async function createKeyfile(password: string) {
     if (!fs.existsSync(fortaKeystore)) {
-      shell.mkdir(fortaKeystore)
+      const mkdirResult = shell.mkdir(fortaKeystore)
+      assertShellResult(mkdirResult, 'error creating keystore folder')
     }
 
     const key = keythereum.create()
@@ -24,7 +25,7 @@ export function provideCreateNewKeyfile(
 
     const publicKey = `0x${keyObject.address}`
     const privateKey = `0x${key.privateKey.toString('hex')}`
-    console.log(`created key ${publicKey} in ${fortaKeystore} folder`)
+    console.log(`created key ${publicKey} in ${fortaKeystore}`)
 
     return {
       publicKey,


### PR DESCRIPTION
if a key already exists when calling `init`, dont create a new one