### PR TITLE
fix .gitignore renaming issue

### DIFF
--- a/cli/commands/init/index.ts
+++ b/cli/commands/init/index.ts
@@ -28,6 +28,10 @@ export default function provideInit(
       // copy files out from js/ts folder
       const copyJsTsResult = shell.cp('-r', isTypescript ? './ts/*' : './js/*', '.')
       assertShellResult(copyJsTsResult, `error unpacking ${isTypescript ? 'ts' : 'js'} folder`)
+      // rename _gitignore to .gitignore
+      // (if we just name it .gitignore, npm publish will rename it to .npmignore 🤷🏻‍♂️)
+      const renameGitignoreResult = shell.mv('_gitignore', '.gitignore')
+      assertShellResult(renameGitignoreResult, 'error renaming gitignore file')
       // remove unused files/folders
       const rmResult = shell.rm('-rf', 'js', 'ts', 'node_modules', '.git')
       assertShellResult(rmResult, 'error cleaning up files')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "forta-agent",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/starter-project/.dockerignore
+++ b/starter-project/.dockerignore
@@ -1,3 +1,2 @@
 node_modules
 dist
-.forta

--- a/starter-project/_gitignore
+++ b/starter-project/_gitignore
@@ -1,3 +1,2 @@
 node_modules
 dist
-.forta


### PR DESCRIPTION
- fixing `.gitignore` renaming issue when publishing
- removing `.forta` from ignore files since its now located at `~/.forta`