### PR TITLE
add npm run scripts for agent

### DIFF
--- a/cli/utils/run.transaction.handlers.on.block.ts
+++ b/cli/utils/run.transaction.handlers.on.block.ts
@@ -25,7 +25,7 @@ export function provideRunTransactionHandlersOnBlock(
       for (const handleTransaction of transactionHandlers) {
         findings.push(...await handleTransaction(txEvent))
       }
-      console.log(`${findings.length} findings for transaction ${txHash}: ${findings}`)
+      console.log(`${findings.length} findings for transaction ${txHash} ${findings}`)
     }
   }
 }

--- a/cli/utils/run.transaction.handlers.on.transaction.ts
+++ b/cli/utils/run.transaction.handlers.on.transaction.ts
@@ -24,6 +24,6 @@ export function provideRunTransactionHandlersOnTransaction(
     for (const handleTransaction of transactionHandlers) {
       findings.push(...await handleTransaction(txEvent))
     }
-    console.log(`${findings.length} findings for transaction ${txHash}: ${findings}`)
+    console.log(`${findings.length} findings for transaction ${txHash} ${findings}`)
   }
 }

--- a/starter-project/js/package.json
+++ b/starter-project/js/package.json
@@ -6,6 +6,10 @@
     "start": "npm run start:dev",
     "start:dev": "nodemon --watch src --watch forta.config.json -e js,json --exec 'forta-agent run'",
     "start:prod": "forta-agent run --prod",
+    "tx": "forta-agent run --tx",
+    "block": "forta-agent run --block",
+    "range": "forta-agent run --range",
+    "file": "forta-agent run --file",
     "test": "jest"
   },
   "dependencies": {

--- a/starter-project/ts/package.json
+++ b/starter-project/ts/package.json
@@ -7,6 +7,10 @@
     "start": "npm run start:dev",
     "start:dev": "nodemon --watch src --watch forta.config.json -e js,ts,json  --exec 'npm run build && forta-agent run'",
     "start:prod": "forta-agent run --prod",
+    "tx": "forta-agent run --tx",
+    "block": "forta-agent run --block",
+    "range": "forta-agent run --range",
+    "file": "forta-agent run --file",
     "test": "jest"
   },
   "dependencies": {


### PR DESCRIPTION
- adding `npm run` scripts to run agents with the locally installed `forta-agent` (having them do `npx forta-agent run` is slow because it has to unpack the npm package first)
- removing `:` from findings console logs