### PR TITLE
Default poolId to agent-devnet

### DIFF
--- a/cli/commands/publish/index.ts
+++ b/cli/commands/publish/index.ts
@@ -89,7 +89,7 @@ export default function providePublish(
         from: publicKey,
         agentId,
         agentIdHash,
-        poolIdText,
+        poolId: poolIdText,
         poolIdHash,
         version,
         timestamp: new Date().toUTCString(),


### PR DESCRIPTION
If not provided, set the poolId to "agent-devnet".