### PR TITLE
retry if tx fetching fails

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
     // "rootDir": "./",                             /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "composite": true,                           /* Enable project compilation */
     // "tsBuildInfoFile": "./",                     /* Specify file to store incremental compilation information */
-    // "removeComments": true,                      /* Do not emit comments to output. */
+    "removeComments": true,                      /* Do not emit comments to output. */
     // "noEmit": true,                              /* Do not emit outputs. */
     // "importHelpers": true,                       /* Import emit helpers from 'tslib'. */
     // "downlevelIteration": true,                  /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */


### PR DESCRIPTION
when subscribing to blockchain data via `forta-agent run`, sometimes the tx/receipt will return null from `web3.eth.getTransaction/Receipt()`. I suspect this is an issue with the websocket json-rpc provider (Infura in my case). this PR adds a single retry if fetching fails, and also prints out an error message if it completely fails (instead of an ugly stacktrace). tested over 50k transactions, observed the error message once