### PR TITLE
add agent documentation to manifest

### DIFF
--- a/cli/di.container.ts
+++ b/cli/di.container.ts
@@ -25,6 +25,7 @@ import { provideCreateKeyfile } from "./utils/create.keyfile"
 import { provideGetTraceData } from './utils/get.trace.data'
 import { FortaConfig } from '../sdk'
 import { CommandName } from '.'
+import provideAddToIpfs from './utils/add.to.ipfs'
 
 export default function configureContainer(commandName: CommandName, cliArgs: any) {
   const container = createContainer({ injectionMode: InjectionMode.CLASSIC });
@@ -68,6 +69,12 @@ export default function configureContainer(commandName: CommandName, cliArgs: an
     runFile: asFunction(provideRunFile),
     runLive: asFunction(provideRunLive),
 
+    documentation: asFunction((fortaConfig: FortaConfig, fortaConfigFilename: string) => {
+      if (!fortaConfig.documentation) {
+        throw new Error(`no documentation provided in ${fortaConfigFilename}`)
+      }
+      return join('.', fortaConfig.documentation)
+    }),
     handlerPaths: asFunction((fortaConfig: FortaConfig, fortaConfigFilename: string) => {
       if (!fortaConfig.handlers || !fortaConfig.handlers.length) {
         throw new Error(`no handlers provided in ${fortaConfigFilename}`)
@@ -81,6 +88,7 @@ export default function configureContainer(commandName: CommandName, cliArgs: an
     getJsonFile: asValue(getJsonFile),
     getKeyfile: asFunction(provideGetKeyfile),
     createKeyfile: asFunction(provideCreateKeyfile),
+    addToIpfs: asFunction(provideAddToIpfs),
 
     getTraceData: asFunction(provideGetTraceData),
     traceRpcUrl: asFunction((fortaConfig: FortaConfig) => {

--- a/cli/utils/add.to.ipfs.ts
+++ b/cli/utils/add.to.ipfs.ts
@@ -1,0 +1,21 @@
+import { AxiosInstance } from "axios"
+import FormData from 'form-data'
+import { assertExists } from "."
+
+// uploads provided string to IPFS and returns IPFS hash
+export type AddToIpfs = (value: string) => Promise<string>
+
+export default function provideAddToIpfs(
+  ipfsHttpClient: AxiosInstance
+) {
+  assertExists(ipfsHttpClient, 'ipfsHttpClient')
+
+  return async function addToIpfs(value: string) {
+    const formData = new FormData()
+    formData.append('value', value)
+    const { data } = await ipfsHttpClient.post('/api/v0/add', formData, {
+      headers: formData.getHeaders()
+    })
+    return data.Hash
+  }
+}

--- a/sdk/index.ts
+++ b/sdk/index.ts
@@ -23,6 +23,7 @@ interface FortaConfig {
   traceRpcUrl?: string
   traceBlockMethod?: string
   traceTransactionMethod?: string
+  documentation?: string
 }
 
 type HandleTransaction = (txEvent: TransactionEvent) => Promise<Finding[]>


### PR DESCRIPTION
allow agent developers to specify a `documentation` file in the config which will be included in the published manifest