### PR TITLE
exclude tests from build

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "forta-agent": "./dist/cli/index.js"
   },
   "scripts": {
-    "build": "tsc && cp -r ./starter-project ./dist && cp ./cli/commands/run/server/agent.proto ./dist/cli/commands/run/server/agent.proto",
+    "build": "tsc --p ./tsconfig.build.json && cp -r ./starter-project ./dist && cp ./cli/commands/run/server/agent.proto ./dist/cli/commands/run/server/agent.proto",
     "publish:local": "npm link",
     "test": "jest"
   },

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["**/*.spec.ts"]
+}


### PR DESCRIPTION
keep jest files out of `dist` folder to reduce package size