### PR TITLE
fix runLive race condition

### DIFF
--- a/cli/commands/run/run.live.ts
+++ b/cli/commands/run/run.live.ts
@@ -18,16 +18,16 @@ export function provideRunLive(
     console.log('listening for blockchain data...')
 
     // process the latest block
-    let currBlockNumber = await web3.eth.getBlockNumber()
-    await runHandlersOnBlock(currBlockNumber)
-    currBlockNumber++
+    let latestBlockNumber = await web3.eth.getBlockNumber()
+    await runHandlersOnBlock(latestBlockNumber)
 
     // poll for the latest block every 15s and process each
     setInterval(async () => {
-      const latestBlockNumber = await web3.eth.getBlockNumber()
-      while (currBlockNumber <= latestBlockNumber) {
-        await runHandlersOnBlock(currBlockNumber)
+      let currBlockNumber = latestBlockNumber
+      latestBlockNumber = await web3.eth.getBlockNumber()
+      while (currBlockNumber < latestBlockNumber) {
         currBlockNumber++
+        await runHandlersOnBlock(currBlockNumber)
       }
     }, 15000)
   }


### PR DESCRIPTION
adjusting `runLive` command to avoid potential race condition that can cause same block to be run twice i.e. if the 2nd invocation of `setInterval` starts before the 1st invocation has completed (and `currBlockNumber` hasn't yet caught up to `latestBlockNumber`), both invocations can run overlapping blocks

example logs:
```
invocation A: currBlockNumber=13141509, latestBlockNumber=13141511
fetching block 13141509...
0 findings for transaction 0x71c6a16c3f6a0227c251b5ad843bab4afad02c720746f30b47f18faef1bf28c8 
invocation A: completed block 13141509
fetching block 13141510...
0 findings for transaction 0x2c8c54491bdbe3f8d29c603c9901e894ae9579899c798097a830884ba8a48508 
invocation A: completed block 13141510
fetching block 13141511...
0 findings for transaction 0x51ca4b8c149c38f9738583e3f29637628d1d8098f643366ee22ed4e0c95dbaa1 
invocation B: currBlockNumber=13141511, latestBlockNumber=13141513
fetching block 13141511...
0 findings for transaction 0x076f633c73922f4c717bf8b1b7d3c3be82928f83591fdf7c1601f36fca90bcb0 
invocation A: completed block 13141511
```