### PR TITLE
runHandlersOnTransaction unit tests; minor refactor to getAgentHandlers

### DIFF
--- a/cli/di.container.ts
+++ b/cli/di.container.ts
@@ -21,7 +21,7 @@ import provideGetCredentials from './commands/publish/get.credentials'
 import provideUploadImage from './commands/publish/upload.image'
 import provideUploadManifest from './commands/publish/upload.manifest'
 import providePushToRegistry from './commands/publish/push.to.registry'
-import { getJsonFile } from "./utils"
+import { createTransactionEvent, getJsonFile } from "./utils"
 import AgentRegistry from "./commands/publish/agent.registry"
 import { provideGetAgentHandlers } from "./utils/get.agent.handlers"
 import { provideGetKeyfile } from "./utils/get.keyfile"
@@ -118,12 +118,13 @@ export default function configureContainer(commandName: CommandName, cliArgs: an
       }
       return [agentPath]
     }),
-    getAgentHandlers: asFunction(provideGetAgentHandlers),
+    getAgentHandlers: asFunction(provideGetAgentHandlers).singleton(),
     getPythonAgentHandlers: asFunction(provideGetPythonAgentHandlers),
     pythonFindingMarker: asValue('!*forta_finding*!:'),
     runHandlersOnBlock: asFunction(provideRunHandlersOnBlock),
     runHandlersOnTransaction: asFunction(provideRunHandlersOnTransaction),
     getJsonFile: asValue(getJsonFile),
+    createTransactionEvent: asValue(createTransactionEvent),
     getKeyfile: asFunction(provideGetKeyfile),
     createKeyfile: asFunction(provideCreateKeyfile),
     addToIpfs: asFunction(provideAddToIpfs),

--- a/cli/utils/get.agent.handlers.ts
+++ b/cli/utils/get.agent.handlers.ts
@@ -13,10 +13,17 @@ export function provideGetAgentHandlers(
   assertExists(handlerPaths, 'handlerPaths')
   assertExists(getPythonAgentHandlers, 'getPythonAgentHandlers')
 
+  let blockHandlers: HandleBlock[]
+  let transactionHandlers: HandleTransaction[]
+
   return async function getAgentHandlers() {
-    const transactionHandlers: HandleTransaction[] = []
-    const blockHandlers: HandleBlock[] = []
-  
+    // only get the agent handlers once
+    if (blockHandlers && transactionHandlers) {
+      return { blockHandlers, transactionHandlers }
+    }
+
+    transactionHandlers = []
+    blockHandlers = []
     try {
       for (let handlerPath of handlerPaths) {
         if (handlerPath.startsWith(`.${path.sep}`)) {
@@ -38,6 +45,6 @@ export function provideGetAgentHandlers(
       throw new Error(`issue getting agent handlers: ${e.message}`)
     }
     
-    return { transactionHandlers, blockHandlers}
+    return { blockHandlers, transactionHandlers }
   }
 }

--- a/cli/utils/index.ts
+++ b/cli/utils/index.ts
@@ -72,7 +72,8 @@ export const createBlockEvent = (block: BlockTransactionObject, networkId: numbe
 }
 
 // creates a Forta TransactionEvent from a web3 TransactionReceipt and BlockTransactionObject
-export const createTransactionEvent = (
+export type CreateTransactionEvent = (receipt: TransactionReceipt, block: BlockTransactionObject, networkId: number, traces: Trace[]) => TransactionEvent
+export const createTransactionEvent: CreateTransactionEvent = (
   receipt: TransactionReceipt, 
   block: BlockTransactionObject, 
   networkId: number, 

--- a/cli/utils/run.handlers.on.block.ts
+++ b/cli/utils/run.handlers.on.block.ts
@@ -15,17 +15,8 @@ export function provideRunHandlersOnBlock(
   assertExists(getAgentHandlers, 'getAgentHandlers')
   assertExists(getTraceData, 'getTraceData')
 
-  let blockHandlers: HandleBlock[]
-  let transactionHandlers: HandleTransaction[]
-
   return async function runHandlersOnBlock(blockHashOrNumber: string | number) {
-    // only get the agent handlers once
-    if (!blockHandlers && !transactionHandlers) {
-      const agentHandlers = await getAgentHandlers()
-      blockHandlers = agentHandlers.blockHandlers
-      transactionHandlers = agentHandlers.transactionHandlers
-    }
-
+    const { blockHandlers, transactionHandlers } = await getAgentHandlers()
     if (!blockHandlers.length && !transactionHandlers.length) {
       throw new Error("no block/transaction handlers found")
     }

--- a/cli/utils/run.handlers.on.transaction.spec.ts
+++ b/cli/utils/run.handlers.on.transaction.spec.ts
@@ -1,0 +1,67 @@
+import { provideRunHandlersOnTransaction, RunHandlersOnTransaction } from "./run.handlers.on.transaction"
+
+describe("runHandlersOnTransaction", () => {
+  let runHandlersOnTransaction: RunHandlersOnTransaction
+  const mockWeb3 = {
+    eth : {
+      getBlock: jest.fn(),
+      getTransactionReceipt: jest.fn(),
+      net: {
+        getId: jest.fn()
+      }
+    }
+  } as any
+  const mockGetAgentHandlers = jest.fn()
+  const mockGetTraceData = jest.fn().mockReturnValue([])
+  const mockCreateTransactionEvent = jest.fn()
+  const mockTxHash = "0x123"
+
+  beforeAll(() => {
+    runHandlersOnTransaction = provideRunHandlersOnTransaction(
+      mockWeb3, mockGetAgentHandlers, mockGetTraceData, mockCreateTransactionEvent
+    )
+  })
+
+  it("throws error if no transaction handlers found", async () => {
+    mockGetAgentHandlers.mockReturnValueOnce({ transactionHandlers: [] })
+
+    try {
+      await runHandlersOnTransaction(mockTxHash)
+    } catch (e) {
+      expect(e.message).toEqual('no transaction handlers found')
+    }
+
+    expect(mockGetAgentHandlers).toHaveBeenCalledTimes(1)
+  })
+
+  it("invokes transaction handlers with transaction event", async () => {
+    mockGetAgentHandlers.mockReset()
+    const mockHandleTransaction = jest.fn().mockReturnValue([])
+    mockGetAgentHandlers.mockReturnValueOnce({ transactionHandlers: [mockHandleTransaction] })
+    const mockNetworkId = 1
+    mockWeb3.eth.net.getId.mockReturnValueOnce(mockNetworkId)
+    const mockReceipt = { blockHash: '0xabc', transactionHash: mockTxHash }
+    mockWeb3.eth.getTransactionReceipt.mockReturnValueOnce(mockReceipt)
+    const mockBlock = { hash: '0xabc' }
+    mockWeb3.eth.getBlock.mockReturnValueOnce(mockBlock)
+    const mockTxEvent = {}
+    mockCreateTransactionEvent.mockReturnValueOnce(mockTxEvent)
+
+    await runHandlersOnTransaction(mockTxHash)
+
+    expect(mockGetAgentHandlers).toHaveBeenCalledTimes(1)
+    expect(mockGetAgentHandlers).toHaveBeenCalledWith()
+    expect(mockWeb3.eth.net.getId).toHaveBeenCalledTimes(1)
+    expect(mockWeb3.eth.net.getId).toHaveBeenCalledWith()
+    expect(mockWeb3.eth.getTransactionReceipt).toHaveBeenCalledTimes(1)
+    expect(mockWeb3.eth.getTransactionReceipt).toHaveBeenCalledWith(mockTxHash)
+    expect(mockWeb3.eth.getBlock).toHaveBeenCalledTimes(1)
+    expect(mockWeb3.eth.getBlock).toHaveBeenCalledWith(mockReceipt.blockHash, true)
+    expect(mockGetTraceData).toHaveBeenCalledTimes(1)
+    expect(mockGetTraceData).toHaveBeenCalledWith(mockReceipt.transactionHash)
+    expect(mockCreateTransactionEvent).toHaveBeenCalledTimes(1)
+    expect(mockCreateTransactionEvent).toHaveBeenCalledWith(mockReceipt, mockBlock, mockNetworkId, [])
+    expect(mockHandleTransaction).toHaveBeenCalledTimes(1)
+    expect(mockHandleTransaction).toHaveBeenCalledWith(mockTxEvent)
+  })
+})

--- a/cli/utils/run.handlers.on.transaction.ts
+++ b/cli/utils/run.handlers.on.transaction.ts
@@ -1,6 +1,5 @@
 import Web3 from "web3";
-import { assertExists, createTransactionEvent } from ".";
-import { HandleTransaction } from "../../sdk";
+import { assertExists, CreateTransactionEvent } from ".";
 import { GetAgentHandlers } from "./get.agent.handlers";
 import { GetTraceData } from "./get.trace.data";
 
@@ -9,21 +8,16 @@ export type RunHandlersOnTransaction = (txHash: string) => Promise<void>
 export function provideRunHandlersOnTransaction(
   web3: Web3,
   getAgentHandlers: GetAgentHandlers,
-  getTraceData: GetTraceData
+  getTraceData: GetTraceData,
+  createTransactionEvent: CreateTransactionEvent
 ): RunHandlersOnTransaction {
   assertExists(web3, 'web3')
   assertExists(getAgentHandlers, 'getAgentHandlers')
   assertExists(getTraceData, 'getTraceData')
+  assertExists(createTransactionEvent, 'createTransactionEvent')
 
-  let transactionHandlers: HandleTransaction[]
-  
   return async function runHandlersOnTransaction(txHash: string) {
-    // only get the agent handlers once
-    if (!transactionHandlers) {
-      const agentHandlers = await getAgentHandlers()
-      transactionHandlers = agentHandlers.transactionHandlers
-    }
-
+    const { transactionHandlers } = await getAgentHandlers()
     if (!transactionHandlers.length) {
       throw new Error("no transaction handlers found")
     }


### PR DESCRIPTION
- runHandlersOnTransaction unit tests
- minor refactor in getAgentHandlers to ensure handlers are only initialized once globally