### PR TITLE
runLive performance improvement

### DIFF
--- a/cli/commands/run/run.live.ts
+++ b/cli/commands/run/run.live.ts
@@ -25,7 +25,8 @@ export function provideRunLive(
     setInterval(async () => {
       let currBlockNumber = latestBlockNumber
       latestBlockNumber = await web3.eth.getBlockNumber()
-      while (currBlockNumber < latestBlockNumber) {
+      const endBlockNumber = latestBlockNumber
+      while (currBlockNumber < endBlockNumber) {
         currBlockNumber++
         await runHandlersOnBlock(currBlockNumber)
       }


### PR DESCRIPTION
when invoking `runLive`, this change ensures that we dont repeat any blocks due to the shared `latestBlockNumber` state