### PR TITLE
fix agentId naming

### DIFF
--- a/cli/commands/publish/push.to.registry.spec.ts
+++ b/cli/commands/publish/push.to.registry.spec.ts
@@ -12,8 +12,7 @@ describe("pushToRegistry", () => {
     createAgent: jest.fn(),
     updateAgent: jest.fn()
   } as any
-  const mockAgentId = "agentId"
-  const mockAgentIdHash = keccak256(mockAgentId)
+  const mockAgentId = "0xagentId"
   const mockManifestRef = "abc123"
   const mockPublicKey = "0x123"
   const mockPrivateKey = "0xabc"
@@ -43,13 +42,13 @@ describe("pushToRegistry", () => {
     expect(mockWeb3.eth.accounts.wallet.add).toHaveBeenCalledWith(mockPrivateKey)
     expect(mockWeb3.eth.accounts.wallet.add).toHaveBeenCalledBefore(mockAgentRegistry.agentExists)
     expect(mockAgentRegistry.agentExists).toHaveBeenCalledTimes(1)
-    expect(mockAgentRegistry.agentExists).toHaveBeenCalledWith(mockAgentIdHash)
+    expect(mockAgentRegistry.agentExists).toHaveBeenCalledWith(mockAgentId)
     expect(mockAgentRegistry.agentExists).toHaveBeenCalledBefore(mockAgentRegistry.createAgent)
     expect(mockAgentRegistry.createAgent).toHaveBeenCalledTimes(1)
-    expect(mockAgentRegistry.createAgent).toHaveBeenCalledWith(mockPublicKey, mockAgentIdHash, mockManifestRef)
+    expect(mockAgentRegistry.createAgent).toHaveBeenCalledWith(mockPublicKey, mockAgentId, mockManifestRef)
     expect(mockAgentRegistry.updateAgent).toHaveBeenCalledTimes(0)
     expect(mockAppendToFile).toHaveBeenCalledTimes(1)
-    expect(mockAppendToFile).toHaveBeenCalledWith(`${systemTime.toUTCString()}: successfully added agent ${mockAgentIdHash} with manifest ${mockManifestRef}`, 'publish.log')
+    expect(mockAppendToFile).toHaveBeenCalledWith(`${systemTime.toUTCString()}: successfully added agent id ${mockAgentId} with manifest ${mockManifestRef}!`, 'publish.log')
     jest.useRealTimers()
   })
 
@@ -64,13 +63,13 @@ describe("pushToRegistry", () => {
     expect(mockWeb3.eth.accounts.wallet.add).toHaveBeenCalledWith(mockPrivateKey)
     expect(mockWeb3.eth.accounts.wallet.add).toHaveBeenCalledBefore(mockAgentRegistry.agentExists)
     expect(mockAgentRegistry.agentExists).toHaveBeenCalledTimes(1)
-    expect(mockAgentRegistry.agentExists).toHaveBeenCalledWith(mockAgentIdHash)
+    expect(mockAgentRegistry.agentExists).toHaveBeenCalledWith(mockAgentId)
     expect(mockAgentRegistry.agentExists).toHaveBeenCalledBefore(mockAgentRegistry.updateAgent)
     expect(mockAgentRegistry.updateAgent).toHaveBeenCalledTimes(1)
-    expect(mockAgentRegistry.updateAgent).toHaveBeenCalledWith(mockPublicKey, mockAgentIdHash, mockManifestRef)
+    expect(mockAgentRegistry.updateAgent).toHaveBeenCalledWith(mockPublicKey, mockAgentId, mockManifestRef)
     expect(mockAgentRegistry.createAgent).toHaveBeenCalledTimes(0)
     expect(mockAppendToFile).toHaveBeenCalledTimes(1)
-    expect(mockAppendToFile).toHaveBeenCalledWith(`${systemTime.toUTCString()}: successfully updated agent ${mockAgentIdHash} with manifest ${mockManifestRef}`, 'publish.log')
+    expect(mockAppendToFile).toHaveBeenCalledWith(`${systemTime.toUTCString()}: successfully updated agent id ${mockAgentId} with manifest ${mockManifestRef}!`, 'publish.log')
     jest.useRealTimers()
   })
 })

--- a/cli/commands/publish/push.to.registry.ts
+++ b/cli/commands/publish/push.to.registry.ts
@@ -21,17 +21,16 @@ export default function providePushToRegistry(
     //make sure web3 knows about this wallet in order to sign the transaction
     web3AgentRegistry.eth.accounts.wallet.add(privateKey);
 
-    const agentIdHash = keccak256(agentId)
-    const agentExists = await agentRegistry.agentExists(agentIdHash)
+    const agentExists = await agentRegistry.agentExists(agentId)
     if (!agentExists) {
       console.log('adding agent to registry...')
-      await agentRegistry.createAgent(publicKey, agentIdHash, manifestReference)
+      await agentRegistry.createAgent(publicKey, agentId, manifestReference)
     } else {
       console.log('updating agent in registry...')
-      await agentRegistry.updateAgent(publicKey, agentIdHash, manifestReference)
+      await agentRegistry.updateAgent(publicKey, agentId, manifestReference)
     }
 
-    const logMessage = `successfully ${agentExists ? 'updated' : 'added'} agent ${agentIdHash} with manifest ${manifestReference}`
+    const logMessage = `successfully ${agentExists ? 'updated' : 'added'} agent id ${agentId} with manifest ${manifestReference}!`
     console.log(logMessage)
     appendToFile(`${new Date().toUTCString()}: ${logMessage}`, 'publish.log')
   }

--- a/cli/commands/publish/upload.image.ts
+++ b/cli/commands/publish/upload.image.ts
@@ -11,12 +11,12 @@ export default function provideUploadImage(
   imageRepositoryUrl: string,
   imageRepositoryUsername: string,
   imageRepositoryPassword: string,
-  agentId: string
+  agentName: string
 ): UploadImage {
   assertExists(shell, 'shell')
   assertExists(prompt, 'prompt')
   assertIsNonEmptyString(imageRepositoryUrl, 'imageRepositoryUrl')
-  assertIsNonEmptyString(agentId, 'agentId')
+  assertIsNonEmptyString(agentName, 'agentName')
 
   return async function uploadImage() {
     // authenticate against repository if credentials provided
@@ -27,7 +27,7 @@ export default function provideUploadImage(
 
     // build the agent image
     console.log('building agent image...')
-    const containerTag = `${agentId}-intermediate`
+    const containerTag = `${agentName}-intermediate`
     const buildResult = shell.exec(`docker build --tag ${containerTag} .`)
     assertShellResult(buildResult, 'error building agent image')
 

--- a/cli/commands/publish/upload.manifest.spec.ts
+++ b/cli/commands/publish/upload.manifest.spec.ts
@@ -11,7 +11,8 @@ describe("uploadManifest", () => {
     readFileSync: jest.fn()
   } as any
   const mockAddToIpfs = jest.fn()
-  const mockAgentId = "agentId"
+  const mockAgentName = "agentName"
+  const mockAgentId = "0xagentId"
   const mockVersion = "0.1"
   const mockDocumentation = "README.md"
   const mockImageRef = "123abc"
@@ -19,7 +20,7 @@ describe("uploadManifest", () => {
   const mockPrivateKey = "0xabc"
 
   beforeAll(() => {
-    uploadManifest = provideUploadManifest(mockWeb3, mockFilesystem, mockAddToIpfs, mockAgentId, mockVersion, mockDocumentation)
+    uploadManifest = provideUploadManifest(mockWeb3, mockFilesystem, mockAddToIpfs, mockAgentName, mockAgentId, mockVersion, mockDocumentation)
   })
 
   it("throws error if documentation not found", async () => {
@@ -46,8 +47,9 @@ describe("uploadManifest", () => {
     mockAddToIpfs.mockReturnValueOnce(mockDocumentationRef)
     const mockManifest = {
       from: mockPublicKey,
-      agentId: mockAgentId,
-      agentIdHash: keccak256(mockAgentId),
+      name: mockAgentName,
+      agentId: mockAgentName,
+      agentIdHash: mockAgentId,
       version: mockVersion,
       timestamp: systemTime.toUTCString(),
       imageReference: mockImageRef,

--- a/cli/commands/publish/upload.manifest.ts
+++ b/cli/commands/publish/upload.manifest.ts
@@ -10,6 +10,7 @@ export default function provideUploadManifest(
   web3AgentRegistry: Web3,
   filesystem: typeof fs,
   addToIpfs: AddToIpfs,
+  agentName: string,
   agentId: string,
   version: string,
   documentation: string,
@@ -17,6 +18,7 @@ export default function provideUploadManifest(
   assertExists(web3AgentRegistry, 'web3AgentRegistry')
   assertExists(filesystem, 'filesystem')
   assertExists(addToIpfs, 'addToIpfs')
+  assertIsNonEmptyString(agentName, 'agentName')
   assertIsNonEmptyString(agentId, 'agentId')
   assertIsNonEmptyString(version, 'version')
   assertIsNonEmptyString(documentation, 'documentation')
@@ -31,11 +33,11 @@ export default function provideUploadManifest(
     const documentationReference = await addToIpfs(documentationFile)
 
     // create agent manifest
-    const agentIdHash = keccak256(agentId)
     const manifest = {
       from: publicKey,
-      agentId,
-      agentIdHash,
+      name: agentName,
+      agentId: agentName,
+      agentIdHash: agentId,
       version,
       timestamp: new Date().toUTCString(),
       imageReference,

--- a/cli/di.container.ts
+++ b/cli/di.container.ts
@@ -21,7 +21,7 @@ import provideGetCredentials from './commands/publish/get.credentials'
 import provideUploadImage from './commands/publish/upload.image'
 import provideUploadManifest from './commands/publish/upload.manifest'
 import providePushToRegistry from './commands/publish/push.to.registry'
-import { createBlockEvent, createTransactionEvent, getJsonFile } from "./utils"
+import { createBlockEvent, createTransactionEvent, getJsonFile, keccak256 } from "./utils"
 import AgentRegistry from "./commands/publish/agent.registry"
 import { provideGetAgentHandlers } from "./utils/get.agent.handlers"
 import { provideGetKeyfile } from "./utils/get.keyfile"
@@ -86,12 +86,9 @@ export default function configureContainer(commandName: CommandName, cliArgs: an
         throw new Error(`unable to parse package.json: ${e.message}`)
       }
     }).singleton(),
-    agentId: asFunction((packageJson: any) => {
-      return packageJson.name
-    }),
-    version: asFunction((packageJson: any) => {
-      return packageJson.version
-    }),
+    agentName: asFunction((packageJson: any) => packageJson.name).singleton(),
+    agentId: asFunction((agentName: string) => keccak256(agentName)).singleton(),
+    version: asFunction((packageJson: any) => packageJson.version),
     documentation: asValue(join(process.cwd(), 'README.md')),
     keyfileName: asFunction((fortaConfig: FortaConfig) => {
       return fortaConfig.keyfile


### PR DESCRIPTION
adjust variable naming where we were referring to the agent's human-readable name as `agentId` (but we should refer to the hash stored in the agent registry as the `agentId`)