### PR TITLE
Avoid duplicated properties in BlockEvent

### DIFF
--- a/cli/commands/run/server/agent.controller.js
+++ b/cli/commands/run/server/agent.controller.js
@@ -83,7 +83,7 @@ module.exports = class AgentController {
   }
 
   createBlockEventFromGrpcRequest(request) {
-    const { type, network, blockHash, blockNumber, block } = request.event;
+    const { type, network, block } = request.event;
 
     const blok = {
       difficulty: block.difficulty,
@@ -111,8 +111,6 @@ module.exports = class AgentController {
     return new BlockEvent(
       type,
       parseInt(network.chainId),
-      blockHash,
-      parseInt(blockNumber),
       blok
     );
   }

--- a/cli/utils/index.ts
+++ b/cli/utils/index.ts
@@ -69,7 +69,7 @@ export const createBlockEvent: CreateBlockEvent = (block: BlockTransactionObject
     transactionsRoot: (block as any).transactionsRoot,
     uncles: block.uncles
   }
-  return new BlockEvent(EventType.BLOCK, networkId, block.hash, block.number, blok)
+  return new BlockEvent(EventType.BLOCK, networkId, blok)
 }
 
 // creates a Forta TransactionEvent from a web3 TransactionReceipt and BlockTransactionObject

--- a/python-sdk/src/forta_agent/block_event.py
+++ b/python-sdk/src/forta_agent/block_event.py
@@ -11,6 +11,12 @@ class BlockEvent:
         networkVal = dict.get('network', "MAINNET")
         self.network = Network[networkVal] if type(
             networkVal) == str else Network(networkVal)
-        self.block_hash = dict.get('blockHash', dict.get('block_hash'))
-        self.block_number = dict.get('blockNumber', dict.get('block_number'))
         self.block = Block(dict.get('block', {}))
+
+    @property
+    def block_hash(self):
+        return self.block.hash
+
+    @property
+    def block_number(self):
+        return self.block.number

--- a/sdk/block.event.ts
+++ b/sdk/block.event.ts
@@ -5,8 +5,14 @@ export class BlockEvent {
   constructor(
     readonly type: EventType,
     readonly network: Network,
-    readonly blockHash: string,
-    readonly blockNumber: number,
     readonly block: Block
   ) {}
+
+  get blockHash() {
+    return this.block.hash
+  }
+
+  get blockNumber() {
+    return this.block.number
+  }
 }


### PR DESCRIPTION
Replace the `readonly` properties of `BlockEvent` for function getters that return the inner block properties 