### PR TITLE
add repository to manifest

### DIFF
--- a/cli/commands/publish/upload.manifest.spec.ts
+++ b/cli/commands/publish/upload.manifest.spec.ts
@@ -15,12 +15,15 @@ describe("uploadManifest", () => {
   const mockAgentId = "0xagentId"
   const mockVersion = "0.1"
   const mockDocumentation = "README.md"
+  const mockRepository = "github.com/myrepository"
   const mockImageRef = "123abc"
   const mockPublicKey = "0x123"
   const mockPrivateKey = "0xabc"
 
   beforeAll(() => {
-    uploadManifest = provideUploadManifest(mockWeb3, mockFilesystem, mockAddToIpfs, mockAgentName, mockAgentId, mockVersion, mockDocumentation)
+    uploadManifest = provideUploadManifest(
+      mockWeb3, mockFilesystem, mockAddToIpfs, mockAgentName, mockAgentId, mockVersion, mockDocumentation, mockRepository
+    )
   })
 
   it("throws error if documentation not found", async () => {
@@ -53,7 +56,9 @@ describe("uploadManifest", () => {
       version: mockVersion,
       timestamp: systemTime.toUTCString(),
       imageReference: mockImageRef,
-      documentation: mockDocumentationRef
+      documentation: mockDocumentationRef,
+      repository: mockRepository,
+      chainIds: [1]
     }
     const mockSignature = "signature"
     mockWeb3.eth.accounts.sign.mockReturnValueOnce({ signature: mockSignature })

--- a/cli/commands/publish/upload.manifest.ts
+++ b/cli/commands/publish/upload.manifest.ts
@@ -14,6 +14,7 @@ export default function provideUploadManifest(
   agentId: string,
   version: string,
   documentation: string,
+  repository: string
 ): UploadManifest {
   assertExists(web3AgentRegistry, 'web3AgentRegistry')
   assertExists(filesystem, 'filesystem')
@@ -41,7 +42,9 @@ export default function provideUploadManifest(
       version,
       timestamp: new Date().toUTCString(),
       imageReference,
-      documentation: documentationReference
+      documentation: documentationReference,
+      repository,
+      chainIds: [1]
     }
 
     // sign agent manifest

--- a/cli/di.container.ts
+++ b/cli/di.container.ts
@@ -95,6 +95,15 @@ export default function configureContainer(commandName: CommandName, cliArgs: an
     agentId: asFunction((agentName: string) => keccak256(agentName)).singleton(),
     version: asFunction((packageJson: any) => packageJson.version),
     documentation: asValue(join(process.cwd(), 'README.md')),
+    repository: asFunction((packageJson: any) => {
+      const repository = packageJson.repository
+      if (typeof repository === 'string') {
+        return repository
+      } else if (typeof repository === 'object') {
+        return repository.url
+      }
+      return undefined
+    }).singleton(),
     keyfileName: asFunction((fortaConfig: FortaConfig) => {
       return fortaConfig.keyfile
     }),


### PR DESCRIPTION
Fixes https://github.com/forta-protocol/forta-node/issues/236

- adding `repository` field to agent manifest (taken from package.json)
- adding `chainIds: [1]` to manifest