### PR TITLE
Added logIndex to filterLog

### DIFF
--- a/sdk/transaction.event.ts
+++ b/sdk/transaction.event.ts
@@ -81,7 +81,7 @@ export class TransactionEvent {
     for (const log of logs) {
       try {
         const parsedLog = iface.parseLog(log);
-        results.push(Object.assign(parsedLog, { address: log.address }));
+        results.push(Object.assign(parsedLog, { address: log.address, logIndex: log.logIndex }));
       } catch (e) {} // TODO see if theres a better way to handle 'no matching event' error
     }
     return results;

--- a/sdk/transaction.event.ts
+++ b/sdk/transaction.event.ts
@@ -14,6 +14,7 @@ export interface TxEventBlock {
 // used for decoded logs, simply including the originating address of the log
 export type LogDescription = ethers.utils.LogDescription & {
   address: string;
+  logIndex: number;
 };
 
 export class TransactionEvent {


### PR DESCRIPTION
The lack of logIndex and the fact that the log object returned from filterLog is not the same object as the logs in the transactionEvent.logs array means it is impossible to test for log order in results returned from a filterLog call.