### PR TITLE
Add addresses to finding

### DIFF
--- a/cli/commands/run/server/agent.proto
+++ b/cli/commands/run/server/agent.proto
@@ -68,6 +68,7 @@ message Finding {
   string description = 7;
   string everestId = 8;
   bool private = 9;
+  repeated string addresses = 10;
 }
 
 message EvaluateTxResponse {

--- a/python-sdk/src/forta_agent/finding.py
+++ b/python-sdk/src/forta_agent/finding.py
@@ -34,6 +34,7 @@ class Finding:
         self.severity = dict['severity']
         self.type = dict['type']
         self.metadata = dict.get('metadata')
+        self.addresses = dict.get('addresses')
 
     def toJson(self):
         d = dict(self.__dict__, **{'alertId': self.alert_id})

--- a/sdk/finding.ts
+++ b/sdk/finding.ts
@@ -25,7 +25,8 @@ export class Finding {
     readonly protocol: string,
     readonly severity: FindingSeverity,
     readonly type: FindingType,
-    readonly metadata: { [key: string]: string}
+    readonly metadata: { [key: string]: string},
+    readonly addresses: string[]
   ) {}
 
   toString() {
@@ -43,7 +44,8 @@ export class Finding {
     protocol = 'ethereum',
     severity,
     type,
-    metadata = {}
+    metadata = {},
+    addresses = []
   } : {
     name: string,
     description: string,
@@ -51,7 +53,8 @@ export class Finding {
     protocol?: string,
     severity: FindingSeverity,
     type: FindingType,
-    metadata?: { [key: string]: string}
+    metadata?: { [key: string]: string},
+    addresses?: string[],
   }) {
     assertIsNonEmptyString(name, 'name')
     assertIsNonEmptyString(description, 'description')
@@ -61,6 +64,6 @@ export class Finding {
     assertIsFromEnum(type, FindingType, 'type')
     // TODO assert metadata keys and values are strings
 
-    return new Finding(name, description, alertId, protocol, severity, type, metadata)
+    return new Finding(name, description, alertId, protocol, severity, type, metadata, addresses)
   }
 }


### PR DESCRIPTION
This adds `addresses` to the finding objects for the SDK so that bots can articulate for what addresses a finding applies.  

The protocol field this populates is here:
https://github.com/forta-network/forta-core-go/blob/master/protocol/agent.proto#L71