### PR TITLE
add more verifications when publishing

### DIFF
--- a/cli/commands/publish/index.spec.ts
+++ b/cli/commands/publish/index.spec.ts
@@ -1,3 +1,4 @@
+import { Wallet } from "ethers"
 import providePublish from "."
 import { CommandHandler } from "../.."
 
@@ -13,7 +14,7 @@ describe("publish", () => {
   })
 
   it("publishes the agent correctly", async () => {
-    const mockPrivateKey = "0x456"
+    const mockPrivateKey = "0x4567"
     mockGetCredentials.mockReturnValueOnce({ privateKey: mockPrivateKey})
     const mockImageRef = "abc123"
     mockUploadImage.mockReturnValueOnce(mockImageRef)
@@ -32,6 +33,9 @@ describe("publish", () => {
     expect(mockUploadManifest).toHaveBeenCalledWith(mockImageRef, mockPrivateKey)
     expect(mockUploadManifest).toHaveBeenCalledBefore(mockPushToRegistry)
     expect(mockPushToRegistry).toHaveBeenCalledTimes(1)
-    expect(mockPushToRegistry).toHaveBeenCalledWith(mockManifestRef, mockPrivateKey)
+    const [manifestRef, fromWallet] = mockPushToRegistry.mock.calls[0]
+    expect(manifestRef).toEqual(mockManifestRef)
+    expect(fromWallet).toBeInstanceOf(Wallet)
+    expect(fromWallet.address).toEqual(new Wallet(mockPrivateKey).address)
   })
 })

--- a/cli/commands/publish/index.ts
+++ b/cli/commands/publish/index.ts
@@ -4,6 +4,7 @@ import { GetCredentials } from '../../utils/get.credentials'
 import { UploadImage } from './upload.image'
 import { UploadManifest } from './upload.manifest'
 import { PushToRegistry } from './push.to.registry'
+import { Wallet } from 'ethers'
 
 export default function providePublish(
   getCredentials: GetCredentials,
@@ -20,6 +21,6 @@ export default function providePublish(
     const imageReference = await uploadImage()
     const { privateKey } = await getCredentials()
     const manifestReference = await uploadManifest(imageReference, privateKey)
-    await pushToRegistry(manifestReference, privateKey)
+    await pushToRegistry(manifestReference, new Wallet(privateKey))
   } 
 }

--- a/cli/commands/publish/push.to.registry.ts
+++ b/cli/commands/publish/push.to.registry.ts
@@ -4,7 +4,7 @@ import { AppendToFile } from '../../utils/append.to.file'
 import AgentRegistry from "../../contracts/agent.registry"
 
 // adds or updates agent to registry contract
-export type PushToRegistry = (manifestReference: string, privateKey: string) => Promise<void>
+export type PushToRegistry = (manifestReference: string, fromWallet: Wallet) => Promise<void>
 
 export default function providePushToRegistry(
   appendToFile: AppendToFile,
@@ -17,14 +17,26 @@ export default function providePushToRegistry(
   assertIsNonEmptyString(agentId, 'agentId')
   assertExists(chainIds, 'chainIds')
   
-  return async function pushToRegistry(manifestReference: string, privateKey: string) {
-    const fromWallet = new Wallet(privateKey)
-    const agentExists = await agentRegistry.agentExists(agentId)
+  return async function pushToRegistry(manifestReference: string, fromWallet: Wallet) {
+    const [agent, fromWalletBalance] = await Promise.all([
+      agentRegistry.getAgent(agentId),
+      fromWallet.getBalance()
+    ])
+    const agentExists = agent.created
+    // verify wallet has some balance to pay transaction fee
+    if (fromWalletBalance.eq(0)) {
+      throw new Error(`insufficient balance to deploy agent for ${fromWallet.address}`)
+    }
 
     if (!agentExists) {
       console.log('adding agent to registry...')
       await agentRegistry.createAgent(fromWallet, agentId, manifestReference, chainIds)
     } else {
+      // verify that the agent is being updated from the same address that created it
+      if (fromWallet.address.toLowerCase() !== agent.owner.toLowerCase()) {
+        throw new Error(`agent can only be updated by owner (${agent.owner})`)
+      }
+
       console.log('updating agent in registry...')
       await agentRegistry.updateAgent(fromWallet, agentId, manifestReference, chainIds)
     }

--- a/cli/contracts/agent.registry.ts
+++ b/cli/contracts/agent.registry.ts
@@ -4,6 +4,12 @@ import AgentRegistryAbi from "./agent.registry.abi.json"
 const GAS_MULTIPLIER = 1.15
 const GAS_PRICE_MULTIPLIER = 1.5
 
+type AgentDescription = {
+  created: boolean;
+  owner: string;
+  metadata: string;
+}
+
 export default class AgentRegistry {
 
   constructor(
@@ -11,9 +17,13 @@ export default class AgentRegistry {
     private agentRegistryContractAddress: string
   ) {}
 
+  async getAgent(agentId: string): Promise<AgentDescription> {
+    return this.getContract().getAgent(agentId)
+  }
+
   async agentExists(agentId: string) {
-    const agent = await this.getContract().getAgent(agentId)
-    return !!agent.metadata
+    const agent = await this.getAgent(agentId)
+    return agent.created
   }
   
   async createAgent(fromWallet: Wallet, agentId: string, reference: string, chainIds: number[]) {


### PR DESCRIPTION
adding more verifications when publishing an agent:
- check deployer wallet has non-zero balance
- check deployer wallet is same as agent owner when updating