### PR TITLE
Adding cli command for agent logs

### DIFF
--- a/cli/commands/logs/index.spec.ts
+++ b/cli/commands/logs/index.spec.ts
@@ -33,7 +33,7 @@ describe("logs", () => {
   beforeEach(() => resetMocks())
 
   beforeAll(() => {
-    logs = provideLogs(mockContainer, mockAgentId, mockGetAgentLogs, "2022-03-20T12:41:00Z", "2022-03-20T13:00:00Z"" )
+    logs = provideLogs(mockContainer, mockAgentId, mockGetAgentLogs, {})
   })
 
   it("throws error if no agentId provided", async () => {

--- a/cli/commands/logs/index.spec.ts
+++ b/cli/commands/logs/index.spec.ts
@@ -1,0 +1,204 @@
+import provideLogs, { getNextMinute, shouldScanForwardOrBackward } from "."
+import { CommandHandler } from "../.."
+
+const data = [
+    {scanner: "0x0", timestamp: "2022-03-20T13:01:00Z", logs: "I am a scanner"},
+    {scanner: "0x1", timestamp: "2022-03-20T12:43:00Z", logs: "Am I a scanner"},
+    {scanner: "0x2", timestamp: "2022-03-20T12:42:00Z", logs: "Why a scanner"},
+    {scanner: "0x3", timestamp: "2022-03-20T12:41:00Z", logs: "What is a scanner"},
+    {scanner: "0x4", timestamp: "2022-03-20T12:40:00Z", logs: "Scanner"}
+]
+
+describe("logs", () => {
+  let logs: CommandHandler
+
+  const mockContainer = {
+    resolve: jest.fn()
+  } as any
+
+  const mockGetAgentLogs = jest.fn();
+
+  const mockAgentsLogs: any[] = data;
+  let consoleSpy = jest.spyOn(console, 'log');
+
+  const mockScannerId = mockAgentsLogs[0].scanner;
+  const mockAgentId = "0x15293"
+
+  const resetMocks = () => {
+    mockContainer.resolve.mockReset()
+    mockGetAgentLogs.mockReset()
+    consoleSpy.mockReset()
+  }
+
+  beforeEach(() => resetMocks())
+
+  beforeAll(() => {
+    logs = provideLogs(mockContainer, mockAgentId, mockGetAgentLogs, "2022-03-20T12:41:00Z", "2022-03-20T13:00:00Z"" )
+  })
+
+  it("throws error if no agentId provided", async () => {
+    try {
+      logs(undefined)
+    } catch(e) {
+      expect(e.message).toBe("No agentId provided")
+    }
+  })
+
+  it("throws error if invalid timestamp provided for --after ", async () => {
+    const earliestTimestamp = "2022-03-20T12:42"
+    try {
+      logs({agentId: mockAgentId, after: earliestTimestamp})
+    } catch(e) {
+      expect(e.message).toBe(`${earliestTimestamp} is not a valid ISO timestamp. The ISO format is: YYYY-MM-DDTHH:mm:ss.sssZ`)
+    }
+  })
+
+  it("throws error if invalid timestamp provided for --before ", async () => {
+    const latestTimestamp = "2022-03-20T12:42"
+    try {
+      logs({agentId: mockAgentId, before: latestTimestamp})
+    } catch(e) {
+      expect(e.message).toBe(`${latestTimestamp} is not a valid ISO timestamp. The ISO format is: YYYY-MM-DDTHH:mm:ss.sssZ`)
+    }
+  })
+
+  it("throws error if the requested latest timestamp is before the earliest timestamp", async () => {
+    const earliestTimestamp = "2022-03-20T12:42:00.000Z"
+    const latestTimestamp = "2022-03-19T12:42:00.000Z"
+    try {
+      logs({agentId: mockAgentId, before: latestTimestamp, after: earliestTimestamp})
+    } catch(e) {
+      expect(e.message).toBe('Provided date range is invalid')
+    }
+  })
+
+
+  it("only prints single log for agent in given 5 minute time range", async () => {
+    const earliestTimestamp = "2022-03-20T13:00:00.000Z";
+    const latestTimestamp = "2022-03-20T13:04:00.000Z";
+
+    mockContainer.resolve.mockReturnValueOnce(mockGetAgentLogs)
+    mockGetAgentLogs.mockReturnValueOnce([mockAgentsLogs[0]]).mockReturnValue([])
+
+    await logs({agentId: mockAgentId, before: latestTimestamp, after: earliestTimestamp})
+
+    expect(mockContainer.resolve).toHaveBeenCalledTimes(1);
+    expect(mockContainer.resolve).toHaveBeenCalledWith("getAgentLogs");
+    expect(mockGetAgentLogs).toHaveBeenCalledTimes(5);
+    expect(consoleSpy).toBeCalledTimes(1)
+  })
+
+  it("only prints 5 logs for agent in given time range", async () => {
+    const earliestTimestamp = "2022-03-20T12:34:00.000Z";
+    const latestTimestamp = "2022-03-20T13:03:00.000Z";
+
+    mockContainer.resolve.mockReturnValueOnce(mockGetAgentLogs)
+
+    mockGetAgentLogs.mockReturnValueOnce([mockAgentsLogs[0]])
+    .mockReturnValueOnce([mockAgentsLogs[1]])
+    .mockReturnValueOnce([mockAgentsLogs[2]])
+    .mockReturnValueOnce([mockAgentsLogs[3]])
+    .mockReturnValueOnce([mockAgentsLogs[4]])
+
+    await logs({agentId: mockAgentId, before: latestTimestamp, after: earliestTimestamp})
+
+    expect(mockContainer.resolve).toHaveBeenCalledTimes(1);
+    expect(mockContainer.resolve).toHaveBeenCalledWith("getAgentLogs");
+    expect(mockGetAgentLogs).toHaveBeenCalledTimes(30); // 1 call for every minute in range
+    expect(consoleSpy).toBeCalledTimes(5)
+  })
+
+
+
+  it("only prints single log for agent with given scannerId", async () => {
+    const earliestTimestamp = "2022-03-20T12:34:00.000Z";
+    const latestTimestamp = "2022-03-20T13:04:00.000Z";
+
+    mockContainer.resolve.mockReturnValueOnce(mockGetAgentLogs)
+
+    mockGetAgentLogs.mockReturnValueOnce([mockAgentsLogs[0]])
+    .mockReturnValueOnce([mockAgentsLogs[1]])
+    .mockReturnValueOnce([mockAgentsLogs[2]])
+    .mockReturnValueOnce([mockAgentsLogs[3]])
+    .mockReturnValueOnce([mockAgentsLogs[4]])
+
+    await logs({agentId: mockAgentId, before: latestTimestamp, after: earliestTimestamp, scannerId: mockScannerId})
+
+    expect(mockContainer.resolve).toHaveBeenCalledTimes(1);
+    expect(mockContainer.resolve).toHaveBeenCalledWith("getAgentLogs");
+    expect(consoleSpy).toBeCalledTimes(1)
+  })
+
+  it("defaults to the last 24 hours of logs if no time range passed in", async () => {
+    const MINUTES_IN_A_DAY = 1440;
+
+    mockContainer.resolve.mockReturnValueOnce(mockGetAgentLogs)
+
+    mockGetAgentLogs.mockReturnValueOnce([])
+
+    await logs({agentId: mockAgentId})
+
+    expect(mockContainer.resolve).toHaveBeenCalledTimes(1);
+    expect(mockContainer.resolve).toHaveBeenCalledWith("getAgentLogs");
+    expect(mockGetAgentLogs).toHaveBeenCalledTimes(MINUTES_IN_A_DAY + 1);
+    expect(consoleSpy).toBeCalledTimes(0)
+  })
+})
+
+describe("shouldScanForwardOrBackward", () => {
+  it("return forward given a range of time", async () => {
+    const earliestTimestamp = "2022-03-20T12:34:00.000Z";
+    const latestTimestamp = "2022-03-20T13:04:00.000Z";
+
+    const result = shouldScanForwardOrBackward(earliestTimestamp, latestTimestamp);
+    expect(result).toBe("forward")
+  }) 
+
+  it("return forward given only an earliest timestamp", async () => {
+    const earliestTimestamp = "2022-03-20T12:34:00.000Z";
+
+    const result = shouldScanForwardOrBackward(earliestTimestamp);
+    expect(result).toBe("forward")
+  }) 
+
+  it("return backward given only an latest timestamp", async () => {
+    const latestTimestamp = "2022-03-20T12:34:00.000Z";
+
+    const result = shouldScanForwardOrBackward(undefined, latestTimestamp);
+    expect(result).toBe("backward")
+  }) 
+})
+
+describe("getNextMinute", () => {
+  it("return undefined if current minute is equal to the latest requested timestamp", async () => {
+    const latestTimestamp = new Date("2022-03-20T13:04:00.000Z");
+    const curTimestamp = latestTimestamp;
+
+    const result = getNextMinute(curTimestamp, "forward", undefined,latestTimestamp);
+    expect(result).toBe(undefined)
+  }) 
+
+  it("return undefined if current minute is equal to the earliest requested timestamp", async () => {
+    const earliestTimestamp = new Date("2022-03-20T13:04:00.000Z");
+    const curTimestamp = earliestTimestamp;
+
+    const result = getNextMinute(curTimestamp, "backward", earliestTimestamp,undefined);
+    expect(result).toBe(undefined)
+  }) 
+
+  it("return Date 1 minute in the future if current minute is less than latest requested timestamp", async () => {
+    const latestTimestamp = new Date("2022-03-20T13:04:00.000Z");
+    const curTimestamp = new Date("2022-03-20T12:04:00.000Z");;
+
+    const result = getNextMinute(curTimestamp, "forward", undefined,latestTimestamp);
+    expect(result?.toISOString()).toBe("2022-03-20T12:05:00.000Z")
+  }) 
+
+  it("return Date 1 minute in the past if current minute is greater than earliest requested timestamp", async () => {
+    const curTimestamp = new Date("2022-03-20T13:04:00.000Z");
+    const earliestTimestamp = new Date("2022-03-20T12:04:00.000Z");;
+
+    const result = getNextMinute(curTimestamp, "backward", earliestTimestamp, undefined);
+    expect(result?.toISOString()).toBe("2022-03-20T13:03:00.000Z")
+  }) 
+})

--- a/cli/commands/logs/index.ts
+++ b/cli/commands/logs/index.ts
@@ -9,16 +9,18 @@ export default function provideLogs(
   container: AwilixContainer,
   agentId: string,
   getAgentLogs: GetAgentLogs,
-  before: string,
-  after: string,
+  args: any,
 ): CommandHandler {
   assertExists(container, 'container')
+  assertExists(args, 'args')
+  assertIsNonEmptyString(agentId, "agentId");
 
   return async function logs(cliArgs: any) {
-    assertIsNonEmptyString(agentId, "agentId");
 
-    let latestTimestamp = before
-    let earliestTimestamp = after
+    args = {...args, ...cliArgs}
+
+    let latestTimestamp = args.before
+    let earliestTimestamp = args.after
 
     // If no time range entered
     if(!latestTimestamp && !earliestTimestamp) {
@@ -31,7 +33,7 @@ export default function provideLogs(
     if(earliestTimestamp) { assertIsISOString(earliestTimestamp) }
     if(latestTimestamp) { assertIsISOString(latestTimestamp)}
 
-    if(!isValidTimeRange(new Date(earliestTimestamp), new Date(latestTimestamp))) throw Error(`Provided date range is invalid`)
+    if(!isValidTimeRange(earliestTimestamp, latestTimestamp)) throw Error(`Provided date range is invalid`)
 
 
     const scanDirection = shouldScanForwardOrBackward(earliestTimestamp, latestTimestamp)
@@ -45,7 +47,7 @@ export default function provideLogs(
       const logs = await getAgentLogs(agentId, curMinute)
 
       if(logs?.length > 0) {
-        logs.filter(log => !cliArgs.scannerId || log.scanner === cliArgs.scannerId) // Filter logs by scannerId if provided
+        logs.filter(log => !args.scannerId || log.scanner === args.scannerId) // Filter logs by scannerId if provided
         .forEach(log => console.log(log))
       }
 

--- a/cli/commands/logs/index.ts
+++ b/cli/commands/logs/index.ts
@@ -1,0 +1,75 @@
+import { AwilixContainer } from 'awilix';
+import { CommandHandler } from "../..";
+import { assertExists, assertIsISOString, assertIsNonEmptyString, isValidTimeRange } from "../../utils";
+import { GetAgentLogs } from '../../utils/get.agent.logs';
+
+const FIVE_MINUTES_IN_SECONDS = 300;
+
+export default function provideLogs(
+  container: AwilixContainer,
+  agentId: string,
+  getAgentLogs: GetAgentLogs,
+  before: string,
+  after: string,
+): CommandHandler {
+  assertExists(container, 'container')
+
+  return async function logs(cliArgs: any) {
+    assertIsNonEmptyString(agentId, "agentId");
+
+    let latestTimestamp = before
+    let earliestTimestamp = after
+
+    // If no time range entered
+    if(!latestTimestamp && !earliestTimestamp) {
+      // Default to the last 5 minutes
+      earliestTimestamp = new Date(Date.now() - (FIVE_MINUTES_IN_SECONDS * 1000)).toISOString()
+      latestTimestamp = new Date(Date.now()).toISOString()
+    }
+
+    // Validate passed in timestamps
+    if(earliestTimestamp) { assertIsISOString(earliestTimestamp) }
+    if(latestTimestamp) { assertIsISOString(latestTimestamp)}
+
+    if(!isValidTimeRange(new Date(earliestTimestamp), new Date(latestTimestamp))) throw Error(`Provided date range is invalid`)
+
+
+    const scanDirection = shouldScanForwardOrBackward(earliestTimestamp, latestTimestamp)
+
+    const earliestDateTime = earliestTimestamp ? new Date(earliestTimestamp) : undefined
+    const latestDateTime = latestTimestamp ? new Date(latestTimestamp) : undefined
+
+    let curMinute: Date | undefined = scanDirection === "forward" ? earliestDateTime : latestDateTime
+
+    while(curMinute) {
+      const logs = await getAgentLogs(agentId, curMinute)
+
+      if(logs?.length > 0) {
+        logs.filter(log => !cliArgs.scannerId || log.scanner === cliArgs.scannerId) // Filter logs by scannerId if provided
+        .forEach(log => console.log(log))
+      }
+
+      curMinute = getNextMinute(curMinute, scanDirection, earliestDateTime, latestDateTime)
+    }
+  }
+}
+
+export type ScanDirection = 'forward' | 'backward';
+
+export const shouldScanForwardOrBackward = (earliestTimestamp?: string, latestTimestamp?: string): ScanDirection => {
+  if(earliestTimestamp && !latestTimestamp) return "forward"
+  else if (latestTimestamp && !earliestTimestamp) return "backward"
+  return "forward"
+}
+
+export const getNextMinute = (curMinute: Date, direction: ScanDirection, earliestDateTime?: Date, latestDateTime?: Date): Date | undefined => {
+  const nextMinute = direction === "forward" 
+    ? new Date(curMinute.getTime() + (60 * 1000))
+    : new Date(curMinute.getTime() - (60 * 1000))
+
+  if(direction === "forward") {
+    return !latestDateTime || nextMinute <= latestDateTime ? nextMinute : undefined
+  } else {
+    return !earliestDateTime || nextMinute >= earliestDateTime ? nextMinute : undefined
+  }
+}

--- a/cli/commands/logs/index.ts
+++ b/cli/commands/logs/index.ts
@@ -24,11 +24,10 @@ export default function provideLogs(
     assertIsISOString(latestTimestamp)
     assertIsISOString(earliestTimestamp)
 
+    const earliestDateTime = new Date(Date.parse(earliestTimestamp))
+    const latestDateTime = new Date(Date.parse(latestTimestamp))
 
-    if(!isValidTimeRange(new Date(earliestTimestamp), new Date(latestTimestamp))) throw Error(`Provided date range is invalid`)
-
-    const earliestDateTime = new Date(earliestTimestamp)
-    const latestDateTime = new Date(latestTimestamp)
+    if(!isValidTimeRange(earliestDateTime, latestDateTime)) throw Error(`Provided date range is invalid`)
 
     let curMinute: Date | undefined = earliestDateTime;
 
@@ -51,5 +50,5 @@ export type ScanDirection = 'forward' | 'backward';
 
 export const getNextMinute = (curMinute: Date, latestDateTime: Date): Date | undefined => {
   const nextMinute = new Date(curMinute.getTime() + (60 * 1000))
-  return !latestDateTime || nextMinute <= latestDateTime ? nextMinute : undefined
+  return nextMinute <= latestDateTime ? nextMinute : undefined
 }

--- a/cli/commands/logs/index.ts
+++ b/cli/commands/logs/index.ts
@@ -3,7 +3,6 @@ import { CommandHandler } from "../..";
 import { assertExists, assertIsISOString, assertIsNonEmptyString, isValidTimeRange } from "../../utils";
 import { GetAgentLogs } from '../../utils/get.agent.logs';
 
-const FIVE_MINUTES_IN_SECONDS = 300;
 
 export default function provideLogs(
   container: AwilixContainer,
@@ -15,33 +14,23 @@ export default function provideLogs(
   assertExists(args, 'args')
   assertIsNonEmptyString(agentId, "agentId");
 
-  return async function logs(cliArgs: any) {
 
-    args = {...args, ...cliArgs}
+  return async function logs(cliArgs: any = {}) {
 
+    args = { ...args, cliArgs }
     let latestTimestamp = args.before
     let earliestTimestamp = args.after
 
-    // If no time range entered
-    if(!latestTimestamp && !earliestTimestamp) {
-      // Default to the last 5 minutes
-      earliestTimestamp = new Date(Date.now() - (FIVE_MINUTES_IN_SECONDS * 1000)).toISOString()
-      latestTimestamp = new Date(Date.now()).toISOString()
-    }
-
-    // Validate passed in timestamps
-    if(earliestTimestamp) { assertIsISOString(earliestTimestamp) }
-    if(latestTimestamp) { assertIsISOString(latestTimestamp)}
-
-    if(!isValidTimeRange(earliestTimestamp, latestTimestamp)) throw Error(`Provided date range is invalid`)
+    assertIsISOString(latestTimestamp)
+    assertIsISOString(earliestTimestamp)
 
 
-    const scanDirection = shouldScanForwardOrBackward(earliestTimestamp, latestTimestamp)
+    if(!isValidTimeRange(new Date(earliestTimestamp), new Date(latestTimestamp))) throw Error(`Provided date range is invalid`)
 
-    const earliestDateTime = earliestTimestamp ? new Date(earliestTimestamp) : undefined
-    const latestDateTime = latestTimestamp ? new Date(latestTimestamp) : undefined
+    const earliestDateTime = new Date(earliestTimestamp)
+    const latestDateTime = new Date(latestTimestamp)
 
-    let curMinute: Date | undefined = scanDirection === "forward" ? earliestDateTime : latestDateTime
+    let curMinute: Date | undefined = earliestDateTime;
 
     while(curMinute) {
       const logs = await getAgentLogs(agentId, curMinute)
@@ -51,27 +40,16 @@ export default function provideLogs(
         .forEach(log => console.log(log))
       }
 
-      curMinute = getNextMinute(curMinute, scanDirection, earliestDateTime, latestDateTime)
+      curMinute = getNextMinute(curMinute, latestDateTime)
     }
   }
 }
 
 export type ScanDirection = 'forward' | 'backward';
 
-export const shouldScanForwardOrBackward = (earliestTimestamp?: string, latestTimestamp?: string): ScanDirection => {
-  if(earliestTimestamp && !latestTimestamp) return "forward"
-  else if (latestTimestamp && !earliestTimestamp) return "backward"
-  return "forward"
-}
 
-export const getNextMinute = (curMinute: Date, direction: ScanDirection, earliestDateTime?: Date, latestDateTime?: Date): Date | undefined => {
-  const nextMinute = direction === "forward" 
-    ? new Date(curMinute.getTime() + (60 * 1000))
-    : new Date(curMinute.getTime() - (60 * 1000))
 
-  if(direction === "forward") {
-    return !latestDateTime || nextMinute <= latestDateTime ? nextMinute : undefined
-  } else {
-    return !earliestDateTime || nextMinute >= earliestDateTime ? nextMinute : undefined
-  }
+export const getNextMinute = (curMinute: Date, latestDateTime: Date): Date | undefined => {
+  const nextMinute = new Date(curMinute.getTime() + (60 * 1000))
+  return !latestDateTime || nextMinute <= latestDateTime ? nextMinute : undefined
 }

--- a/cli/di.container.ts
+++ b/cli/di.container.ts
@@ -48,6 +48,8 @@ import provideInitKeystore from './utils/init.keystore'
 import provideInitKeyfile from './utils/init.keyfile'
 import provideInitConfig from './utils/init.config'
 import provideGetLogsForBlock from './utils/get.logs.for.block'
+import { provideGetAgentLogs } from './utils/get.agent.logs'
+import provideLogs from './commands/logs'
 
 export default function configureContainer(args: any = {}) {
   const container = createContainer({ injectionMode: InjectionMode.CLASSIC });
@@ -91,6 +93,7 @@ export default function configureContainer(args: any = {}) {
 
     init: asFunction(provideInit),
     run: asFunction(provideRun),
+    logs: asFunction(provideLogs),
     publish: asFunction(providePublish),
     push: asFunction(providePush),
     disable: asFunction(provideDisable),
@@ -185,6 +188,8 @@ export default function configureContainer(args: any = {}) {
     getLogsForBlock: asFunction(provideGetLogsForBlock),
 
     getTraceData: asFunction(provideGetTraceData),
+    getAgentLogs: asFunction(provideGetAgentLogs),
+    fortaApiUrl: asValue('https://api.forta.network'),
     traceRpcUrl: asFunction((fortaConfig: FortaConfig) => {
       return fortaConfig.traceRpcUrl
     }).singleton(),

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -2,7 +2,7 @@
 import yargs, { Argv } from 'yargs';
 import configureContainer from './di.container';
 
-type CommandName = "init" | "run" | "publish" | "push" | "disable" | "enable" | "keyfile"
+type CommandName = "init" | "run" | "publish" | "push" | "disable" | "enable" | "keyfile" | "logs"
 export type CommandHandler = (args?: any) => Promise<void>
 
 async function executeCommand(cliCommandName: CommandName, cliArgs: any) {
@@ -83,5 +83,23 @@ yargs
     (yargs: Argv) => {},
     (cliArgs: any) => executeCommand("keyfile", cliArgs)
   )
+  .command('logs', 'Retrieve logs on Forta Agent',
+    (yargs: Argv) => {
+      yargs
+      .option('after', {
+        description: 'An ISO timestamp representing the oldest time to include in logs',
+        type: 'string'
+      }).option('before', {
+        description: 'An ISO timestamp representing the latest time to include in logs',
+        type: 'string'
+      }).option('agentId', {
+        description: 'Id of agent',
+        type: 'string'
+      })
+    },
+    (cliArgs: any) => {
+      console.log(`Excecuting cliArgs: ${cliArgs}`)
+      executeCommand("logs", cliArgs)
+    })
   .strict()
   .argv

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -92,14 +92,12 @@ yargs
       }).option('before', {
         description: 'An ISO timestamp representing the latest time to include in logs',
         type: 'string'
-      }).option('agentId', {
-        description: 'Id of agent',
+      }).option('scannerId', {
+        description: 'Only returns logs for specified scannerId',
         type: 'string'
       })
     },
-    (cliArgs: any) => {
-      console.log(`Excecuting cliArgs: ${cliArgs}`)
-      executeCommand("logs", cliArgs)
-    })
+    (cliArgs: any) => executeCommand("logs", cliArgs)
+  )
   .strict()
   .argv

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -86,6 +86,8 @@ yargs
   .command('logs', 'Retrieve logs on Forta Agent',
     (yargs: Argv) => {
       yargs
+      .requiresArg('before')
+      .requiresArg('after')
       .option('after', {
         description: 'An ISO timestamp representing the oldest time to include in logs',
         type: 'string'

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -86,15 +86,15 @@ yargs
   .command('logs', 'Retrieve logs on Forta Agent',
     (yargs: Argv) => {
       yargs
-      .requiresArg('before')
-      .requiresArg('after')
       .option('after', {
         description: 'An ISO timestamp representing the oldest time to include in logs',
         type: 'string'
       }).option('before', {
         description: 'An ISO timestamp representing the latest time to include in logs',
         type: 'string'
-      }).option('scannerId', {
+      }).demandOption('before')
+      .demandOption('after')
+      .option('scannerId', {
         description: 'Only returns logs for specified scannerId',
         type: 'string'
       })

--- a/cli/utils/get.agent.logs.spec.ts
+++ b/cli/utils/get.agent.logs.spec.ts
@@ -1,0 +1,73 @@
+import { GetAgentLogs, provideGetAgentLogs } from "./get.agent.logs"
+
+const data = [
+    {scanner: "0x0", timestamp: "2022-03-20T13:01:00Z", logs: "I am a scanner"},
+    {scanner: "0x1", timestamp: "2022-03-20T12:43:00Z", logs: "Am I a scanner"},
+    {scanner: "0x2", timestamp: "2022-03-20T12:42:00Z", logs: "Why a scanner"},
+    {scanner: "0x3", timestamp: "2022-03-20T12:41:00Z", logs: "What is a scanner"},
+    {scanner: "0x4", timestamp: "2022-03-20T12:40:00Z", logs: "Scanner"}
+]
+
+describe("getAgentLogs", () => {
+  let getAgentLogs: GetAgentLogs
+  const mockFortaApiUrl = "https://api.test"
+  const mockAxios = {
+    get: jest.fn()
+  } as any
+
+  const mockAgentsLogs: any[] = data;
+  const mockAgentId = "0x15293"
+
+  const resetMocks = () => {
+    mockAxios.get.mockReset()
+  }
+
+  beforeEach(() => resetMocks())
+
+  beforeAll(() => {
+    getAgentLogs = provideGetAgentLogs(mockAxios, mockFortaApiUrl)
+  })
+
+  it("returns empty array when know fortaApiUrl is provided", async () => {
+    const getAgentLogs = provideGetAgentLogs(mockAxios, "")
+
+    await getAgentLogs(mockAgentId, new Date())
+    expect(mockAxios.get).toHaveBeenCalledTimes(0)
+  })
+
+  it("returns array with single log found during a given minute", async () => {
+    const moment = new Date(Date.parse("2022-03-20T12:42:00Z"));
+
+    mockAxios.get.mockReturnValueOnce(
+      { data: mockAgentsLogs.filter(log => new Date(log.timestamp).toISOString() === moment.toISOString())}
+    );
+
+    const logs = await getAgentLogs(mockAgentId, moment);
+    expect(mockAxios.get).toHaveBeenCalledTimes(1);
+    expect(logs.length).toBe(1);
+  })
+
+  it("returns empty array logs when no logs found during a given minute", async () => {
+    const moment = new Date(Date.parse("1990-03-20T12:42:00Z"));
+
+      mockAxios.get.mockReturnValueOnce(
+        { data: mockAgentsLogs.filter(log => new Date(log.timestamp).toISOString() === moment.toISOString())}
+      )
+
+      const logs = await getAgentLogs(mockAgentId, moment);
+      expect(mockAxios.get).toHaveBeenCalledTimes(1)
+      expect(logs.length).toBe(0)
+  })
+
+  it("throws error if network request fail", async () => {
+    const moment = new Date(Date.parse("1990-03-20T12:42:00Z"));
+    const errorMessage = "Failed to make network request"
+    try {
+      mockAxios.get.mockReturnValueOnce({data: {error: {message: errorMessage}}})
+      await getAgentLogs(mockAgentId, moment);
+    } catch (e) {
+      expect(mockAxios.get).toHaveBeenCalledTimes(1)
+      expect(e.message).toBe(errorMessage)
+    }
+  })
+})

--- a/cli/utils/get.agent.logs.ts
+++ b/cli/utils/get.agent.logs.ts
@@ -1,0 +1,33 @@
+import { AxiosStatic } from "axios";
+import { assertExists } from ".";
+
+export type GetAgentLogs = (agentId: string, minute: Date) => Promise<any[]>
+
+export function provideGetAgentLogs(
+  axios: AxiosStatic,
+  fortaApiUrl: string,
+): GetAgentLogs {
+  assertExists(axios, 'axios')
+
+  return async function getAgentLogs(agentId: string, minute: Date) {
+   
+    if( !fortaApiUrl?.length) return [];
+
+    try {
+      const { data } = await axios.get(`${fortaApiUrl}/logs/agents/${agentId}`, {
+        headers: {
+          "accept": "application/json",
+        },
+        params: {
+          minute: minute.toISOString()
+        }
+      });
+
+      if (data?.error) throw new Error(data.error.message);
+
+      return data;
+    } catch(err) {
+      console.log(`Error retrieving agent because ${err}`)
+    }
+  }
+}

--- a/cli/utils/index.spec.ts
+++ b/cli/utils/index.spec.ts
@@ -1,5 +1,5 @@
 import { getContractAddress } from '@ethersproject/address'
-import { createBlockEvent, createTransactionEvent, formatAddress, keccak256 } from "."
+import { assertIsISOString, createBlockEvent, createTransactionEvent, formatAddress, isValidTimeRange, keccak256 } from "."
 import { BlockEvent, EventType, Network, TransactionEvent } from "../../sdk"
 
 describe("keccak256", () => {
@@ -19,6 +19,54 @@ describe("formatAddress", () => {
     const formattedAddress = formatAddress(address)
 
     expect(formattedAddress).toEqual("0xabc123def")
+  })
+})
+
+describe("assertIsISOString", () => {
+  it("does not throw error for valid ISO string", () => {
+    const isoString = "2022-03-20T12:42:00.000Z"
+    assertIsISOString(isoString)
+  })
+
+  it("does not throw error for invalid ISO string", () => {
+    const isoString = "2022-03-20T12:42"
+    assertIsISOString(isoString)
+  })
+})
+
+describe("isValidTimeRange", () => {
+  it("should return true for valid time range", () => {
+    const earliestTimestamp = new Date("2022-03-20T12:42:00Z");
+    const latestTimestamp = new Date("2022-03-22T12:42:00Z");
+    const isValid = isValidTimeRange(earliestTimestamp, latestTimestamp);
+
+    expect(isValid).toBe(true)
+  })
+
+  it("should return true given only an earliestTimestamp", () => {
+    const earliestTimestamp = new Date("2022-03-20T12:42:00Z");
+    const isValid = isValidTimeRange(earliestTimestamp, undefined);
+
+    expect(isValid).toBe(true)
+  })
+
+  it("should return true given only an latestTimestamp", () => {
+    const latestTimestamp = new Date("2022-03-20T12:42:00Z");
+    const isValid = isValidTimeRange(undefined, latestTimestamp);
+
+    expect(isValid).toBe(true)
+  })
+
+  it("should return true when no dates passed in", () => {
+    const isValid = isValidTimeRange(undefined, undefined);
+    expect(isValid).toBe(true)
+  })
+
+  it("should return false if earliestTimestamp is after the latestTimestamp", () => {
+    const earliestTimestamp = new Date("2022-03-20T12:42:00Z");
+    const latestTimestamp = new Date("2022-03-19T12:42:00Z");
+    const isValid = isValidTimeRange(earliestTimestamp, latestTimestamp);
+    expect(isValid).toBe(false)
   })
 })
 

--- a/cli/utils/index.ts
+++ b/cli/utils/index.ts
@@ -30,10 +30,27 @@ export const assertIsNonEmptyString = (str: string, varName: string) => {
   }
 };
 
+export const assertIsISOString = (str: string) => {
+  let parsedDate = new Date(Date.parse(str))
+
+  if(parsedDate.toISOString() !== str) {
+    throw new Error(`${str} is not a valid ISO timestamp. The ISO format is: YYYY-MM-DDTHH:mm:ss.sssZ`)
+  }
+}
+
 export const assertShellResult = (result: ShellString, errMsg: string) => {
   if (result.code !== 0) {
     throw new Error(`${errMsg}: ${result.stderr}`)
   }
+}
+
+export const isValidTimeRange = (earliestTimestamp?: Date, latestTimestamp?: Date): boolean => {
+  // If given a start range and end range
+  if(earliestTimestamp && latestTimestamp) {
+    return earliestTimestamp < latestTimestamp;
+  } else { 
+    return true;
+  };
 }
 
 export const keccak256 = (str: string) => {

--- a/cli/utils/index.ts
+++ b/cli/utils/index.ts
@@ -31,10 +31,8 @@ export const assertIsNonEmptyString = (str: string, varName: string) => {
 };
 
 export const assertIsISOString = (str: string) => {
-  let parsedDate = new Date(Date.parse(str))
-
-  if(parsedDate.toISOString() !== str) {
-    throw new Error(`${str} is not a valid ISO timestamp. The ISO format is: YYYY-MM-DDTHH:mm:ss.sssZ`)
+  if(isNaN(Date.parse(str))) {
+    throw new Error(`${str} is not a valid ISO timestamp. The ISO format is: YYYY-MM-DDTHH:mmZ`)
   }
 }
 
@@ -44,13 +42,9 @@ export const assertShellResult = (result: ShellString, errMsg: string) => {
   }
 }
 
-export const isValidTimeRange = (earliestTimestamp?: Date, latestTimestamp?: Date): boolean => {
+export const isValidTimeRange = (earliestTimestamp: Date, latestTimestamp: Date): boolean => {
   // If given a start range and end range
-  if(earliestTimestamp && latestTimestamp) {
-    return earliestTimestamp < latestTimestamp;
-  } else { 
-    return true;
-  };
+  return earliestTimestamp < latestTimestamp;
 }
 
 export const keccak256 = (str: string) => {


### PR DESCRIPTION
Adding new cli command logs for forta-agent cli. This command has the following options:

Required: 
- [ ]  `before`: An ISO timestamp [`YYYY-MM-DDTHH:mmZ`] representing the latest time to include in logs
- [ ]  `after`: An ISO timestamp [`YYYY-MM-DDTHH:mmZ`] representing the oldest time to include in logs

Optional:
- [ ] `scannerId`: Filter to only return logs of a given scannerId

The `agentId` is read from `forta.config.json`.


https://user-images.githubusercontent.com/40375385/169033499-47721195-df58-487a-9aee-4460d5071ff4.mov

