### PR TITLE
Validate network ID when running bot

### DIFF
--- a/cli/commands/run/index.spec.ts
+++ b/cli/commands/run/index.spec.ts
@@ -9,22 +9,42 @@ describe("run", () => {
   const mockCache = {
     save: jest.fn()
   } as any
+  const mockEthersProvider = {
+    getNetwork: jest.fn()
+  } as any
   const mockExit = jest.spyOn(process, 'exit').mockImplementation();
 
   const resetMocks = () => {
     mockContainer.resolve.mockReset()
+    mockEthersProvider.getNetwork.mockReset()
     mockCache.save.mockReset()
     mockExit.mockReset()
   }
 
-  beforeEach(() => resetMocks())
+  const defaultChainIds = [1];
+
+  beforeEach(() => {
+    resetMocks();
+    (mockEthersProvider.getNetwork as jest.Mock<any,any>).mockReturnValueOnce({chainId: 1, name: "test"})
+  })
+
+  it("throws an error if detected chainId is not in list of configured chainIds", async () => {
+    resetMocks();
+    (mockEthersProvider.getNetwork as jest.Mock<any,any>).mockReturnValueOnce({chainId: 234, name: "test"})
+
+    try{
+      run = provideRun(mockContainer, mockEthersProvider, defaultChainIds, mockCache, {})
+    } catch(e) {
+      expect(e.message).toBe(`Detected chainId [234] is missing from the package.json.`)
+    }
+  })
 
   it("invokes runTransaction if --tx argument is provided", async () => {
     const mockCliArgs = {tx: '0x123'}
     const mockRunTransaction = jest.fn()
     mockContainer.resolve.mockReturnValueOnce(mockRunTransaction)
 
-    run = provideRun(mockContainer, mockCache, mockCliArgs)
+    run = provideRun(mockContainer, mockEthersProvider, defaultChainIds, mockCache, mockCliArgs)
     await run()
 
     expect(mockContainer.resolve).toHaveBeenCalledTimes(1)
@@ -41,7 +61,7 @@ describe("run", () => {
     const mockRunBlock = jest.fn()
     mockContainer.resolve.mockReturnValueOnce(mockRunBlock)
 
-    run = provideRun(mockContainer, mockCache, mockCliArgs)
+    run = provideRun(mockContainer, mockEthersProvider, defaultChainIds, mockCache, mockCliArgs)
     await run()
 
     expect(mockContainer.resolve).toHaveBeenCalledTimes(1)
@@ -58,7 +78,7 @@ describe("run", () => {
     const mockRunBlockRange = jest.fn()
     mockContainer.resolve.mockReturnValueOnce(mockRunBlockRange)
 
-    run = provideRun(mockContainer, mockCache, mockCliArgs)
+    run = provideRun(mockContainer, mockEthersProvider, defaultChainIds, mockCache, mockCliArgs)
     await run()
 
     expect(mockContainer.resolve).toHaveBeenCalledTimes(1)
@@ -75,7 +95,7 @@ describe("run", () => {
     const mockRunFile = jest.fn()
     mockContainer.resolve.mockReturnValueOnce(mockRunFile)
 
-    run = provideRun(mockContainer, mockCache, mockCliArgs)
+    run = provideRun(mockContainer, mockEthersProvider, defaultChainIds, mockCache, mockCliArgs)
     await run()
 
     expect(mockContainer.resolve).toHaveBeenCalledTimes(1)
@@ -92,7 +112,7 @@ describe("run", () => {
     const mockRunProdServer = jest.fn()
     mockContainer.resolve.mockReturnValueOnce(mockRunProdServer)
 
-    run = provideRun(mockContainer, mockCache, mockCliArgs)
+    run = provideRun(mockContainer, mockEthersProvider, defaultChainIds, mockCache, mockCliArgs)
     await run()
 
     expect(mockContainer.resolve).toHaveBeenCalledTimes(1)
@@ -109,7 +129,7 @@ describe("run", () => {
     const mockRunLive = jest.fn()
     mockContainer.resolve.mockReturnValueOnce(mockRunLive)
 
-    run = provideRun(mockContainer, mockCache, mockCliArgs)
+    run = provideRun(mockContainer, mockEthersProvider, defaultChainIds, mockCache, mockCliArgs)
     await run()
 
     expect(mockContainer.resolve).toHaveBeenCalledTimes(1)

--- a/cli/commands/run/index.spec.ts
+++ b/cli/commands/run/index.spec.ts
@@ -22,20 +22,21 @@ describe("run", () => {
   }
 
   const defaultChainIds = [1];
+  const testRpcUrl = "https://test.com";
 
   beforeEach(() => {
     resetMocks();
-    (mockEthersProvider.getNetwork as jest.Mock<any,any>).mockReturnValueOnce({chainId: 1, name: "test"})
+    (mockEthersProvider.getNetwork as jest.Mock).mockReturnValueOnce({chainId: 1, name: "test"})
   })
 
   it("throws an error if detected chainId is not in list of configured chainIds", async () => {
     resetMocks();
-    (mockEthersProvider.getNetwork as jest.Mock<any,any>).mockReturnValueOnce({chainId: 234, name: "test"})
+    (mockEthersProvider.getNetwork as jest.Mock).mockReturnValueOnce({chainId: 234, name: "test"})
 
     try{
-      run = provideRun(mockContainer, mockEthersProvider, defaultChainIds, mockCache, {})
+      run = provideRun(mockContainer, mockEthersProvider, defaultChainIds, testRpcUrl, mockCache, {})
     } catch(e) {
-      expect(e.message).toBe(`Detected chainId [234] is missing from the package.json.`)
+      expect(e.message).toBe(`Detected chainId mismatch between ${testRpcUrl} [chainId: 234] and package.json [chainIds: 1].`)
     }
   })
 
@@ -44,7 +45,7 @@ describe("run", () => {
     const mockRunTransaction = jest.fn()
     mockContainer.resolve.mockReturnValueOnce(mockRunTransaction)
 
-    run = provideRun(mockContainer, mockEthersProvider, defaultChainIds, mockCache, mockCliArgs)
+    run = provideRun(mockContainer, mockEthersProvider, defaultChainIds, testRpcUrl, mockCache, mockCliArgs)
     await run()
 
     expect(mockContainer.resolve).toHaveBeenCalledTimes(1)
@@ -61,7 +62,7 @@ describe("run", () => {
     const mockRunBlock = jest.fn()
     mockContainer.resolve.mockReturnValueOnce(mockRunBlock)
 
-    run = provideRun(mockContainer, mockEthersProvider, defaultChainIds, mockCache, mockCliArgs)
+    run = provideRun(mockContainer, mockEthersProvider, defaultChainIds, testRpcUrl, mockCache, mockCliArgs)
     await run()
 
     expect(mockContainer.resolve).toHaveBeenCalledTimes(1)
@@ -78,7 +79,7 @@ describe("run", () => {
     const mockRunBlockRange = jest.fn()
     mockContainer.resolve.mockReturnValueOnce(mockRunBlockRange)
 
-    run = provideRun(mockContainer, mockEthersProvider, defaultChainIds, mockCache, mockCliArgs)
+    run = provideRun(mockContainer, mockEthersProvider, defaultChainIds, testRpcUrl, mockCache, mockCliArgs)
     await run()
 
     expect(mockContainer.resolve).toHaveBeenCalledTimes(1)
@@ -95,7 +96,7 @@ describe("run", () => {
     const mockRunFile = jest.fn()
     mockContainer.resolve.mockReturnValueOnce(mockRunFile)
 
-    run = provideRun(mockContainer, mockEthersProvider, defaultChainIds, mockCache, mockCliArgs)
+    run = provideRun(mockContainer, mockEthersProvider, defaultChainIds, testRpcUrl, mockCache, mockCliArgs)
     await run()
 
     expect(mockContainer.resolve).toHaveBeenCalledTimes(1)
@@ -112,7 +113,7 @@ describe("run", () => {
     const mockRunProdServer = jest.fn()
     mockContainer.resolve.mockReturnValueOnce(mockRunProdServer)
 
-    run = provideRun(mockContainer, mockEthersProvider, defaultChainIds, mockCache, mockCliArgs)
+    run = provideRun(mockContainer, mockEthersProvider, defaultChainIds, testRpcUrl, mockCache, mockCliArgs)
     await run()
 
     expect(mockContainer.resolve).toHaveBeenCalledTimes(1)
@@ -129,7 +130,7 @@ describe("run", () => {
     const mockRunLive = jest.fn()
     mockContainer.resolve.mockReturnValueOnce(mockRunLive)
 
-    run = provideRun(mockContainer, mockEthersProvider, defaultChainIds, mockCache, mockCliArgs)
+    run = provideRun(mockContainer, mockEthersProvider, defaultChainIds, testRpcUrl, mockCache, mockCliArgs)
     await run()
 
     expect(mockContainer.resolve).toHaveBeenCalledTimes(1)

--- a/cli/commands/run/index.ts
+++ b/cli/commands/run/index.ts
@@ -1,4 +1,5 @@
 import { AwilixContainer } from 'awilix';
+import { providers } from 'ethers';
 import { Cache } from 'flat-cache';
 import { CommandHandler } from '../..';
 import { assertExists } from '../../utils';
@@ -11,15 +12,25 @@ import { RunProdServer } from './server';
 
 export default function provideRun(
   container: AwilixContainer,
+  ethersProvider: providers.JsonRpcProvider,
+  chainIds: number[],
   cache: Cache,
   args: any
 ): CommandHandler {
   assertExists(container, 'container')
   assertExists(cache, 'cache')
+  assertExists(chainIds, 'chainIds')
+  assertExists(ethersProvider, "ethersProvider");
   assertExists(args, 'args')
 
   return async function run(runtimeArgs: any = {}) {
     args = { ...args, ...runtimeArgs }
+
+    const network = await ethersProvider.getNetwork();
+
+    if(!network) throw Error(`No network detected at rpc url.`);
+
+    if(!chainIds.includes(network.chainId)) throw Error(`Detected chainId [${network.chainId}] is missing from the package.json.`)
 
     // we manually inject the run functions here (instead of through the provide function above) so that
     // we get RUNTIME errors if certain configuration is missing for that run function e.g. jsonRpcUrl

--- a/cli/commands/run/index.ts
+++ b/cli/commands/run/index.ts
@@ -14,6 +14,7 @@ export default function provideRun(
   container: AwilixContainer,
   ethersProvider: providers.JsonRpcProvider,
   chainIds: number[],
+  jsonRpcUrl: string,
   cache: Cache,
   args: any
 ): CommandHandler {
@@ -28,9 +29,9 @@ export default function provideRun(
 
     const network = await ethersProvider.getNetwork();
 
-    if(!network) throw Error(`No network detected at rpc url.`);
+    if(!network) throw Error(`No network detected at rpc url: ${jsonRpcUrl}`);
 
-    if(!chainIds.includes(network.chainId)) throw Error(`Detected chainId [${network.chainId}] is missing from the package.json.`)
+    if(!chainIds.includes(network.chainId)) throw Error(`Detected chainId mismatch between ${jsonRpcUrl} [chainId: ${network.chainId}] and package.json [chainIds: ${chainIds}].`)
 
     // we manually inject the run functions here (instead of through the provide function above) so that
     // we get RUNTIME errors if certain configuration is missing for that run function e.g. jsonRpcUrl


### PR DESCRIPTION
Validate the chainId of the network found from the jsonRpcUrl is listed inside the package.json list of chainId's.

Validated by setting my rpc url to a Fantom node but only listing Etherum's chainId in my package.json.
<img width="544" alt="Screen Shot 2022-05-20 at 9 39 58 AM" src="https://user-images.githubusercontent.com/40375385/169541226-4c7d7117-790c-47c4-bbf6-151800123b40.png">
