### PR TITLE
Adjust block polling time based on chainId when running bot locally live

### DIFF
--- a/cli/commands/run/run.live.ts
+++ b/cli/commands/run/run.live.ts
@@ -20,6 +20,9 @@ export function provideRunLive(
 
     const network = await ethersProvider.getNetwork();
     const { chainId } = network;
+
+    const { blockTimeInSeconds } = getBlockChainNetworkConfig(chainId)
+    
     // poll for latest blocks
     while (shouldContinuePolling()) {
       const latestBlockNumber = await ethersProvider.getBlockNumber();
@@ -30,7 +33,7 @@ export function provideRunLive(
       // if no new blocks
       if (currBlockNumber > latestBlockNumber) {
         // wait for a bit
-        const { blockTimeInSeconds } = getBlockChainNetworkConfig(chainId)
+
         await sleep(blockTimeInSeconds);
       } else {
         // process new blocks

--- a/cli/commands/run/run.live.ts
+++ b/cli/commands/run/run.live.ts
@@ -1,5 +1,5 @@
 import { providers } from "ethers";
-import { assertExists } from "../../utils";
+import { assertExists, getBlockChainNetworkConfig } from "../../utils";
 import { RunHandlersOnBlock } from "../../utils/run.handlers.on.block";
 
 // runs agent handlers against live blockchain data
@@ -18,6 +18,8 @@ export function provideRunLive(
     console.log("listening for blockchain data...");
     let currBlockNumber;
 
+    const network = await ethersProvider.getNetwork();
+    const { chainId } = network;
     // poll for latest blocks
     while (shouldContinuePolling()) {
       const latestBlockNumber = await ethersProvider.getBlockNumber();
@@ -28,7 +30,8 @@ export function provideRunLive(
       // if no new blocks
       if (currBlockNumber > latestBlockNumber) {
         // wait for a bit
-        await sleep(15000);
+        const { blockTimeInSeconds } = getBlockChainNetworkConfig(chainId)
+        await sleep(blockTimeInSeconds);
       } else {
         // process new blocks
         while (currBlockNumber <= latestBlockNumber) {

--- a/cli/utils/index.ts
+++ b/cli/utils/index.ts
@@ -190,3 +190,75 @@ export const createTransactionEvent: CreateTransactionEvent = (
     contractAddress
   )
 }
+
+type NetworkName = "ethereum" | "polygon" | "binance_smart_chain" | "avalanche" | "arbitrum" | "optimism" | "fantom";
+
+const DEFAULTS_BLOCK_TIME_IN_SECONDS = 15;
+
+export interface BlockchainNetworkConfig {
+  chainId: number,
+  blockTimeInSeconds: number
+}
+
+
+export const getBlockChainNetworkConfig = (chainId: number): BlockchainNetworkConfig => {
+  switch(chainId) {
+    case(1): {
+      return SUPPORTED_NETWORKS['ethereum']
+    }
+    case(137): {
+      return SUPPORTED_NETWORKS['polygon']
+    }
+    case(56): {
+      return SUPPORTED_NETWORKS['binance_smart_chain']
+    }
+    case(43114): {
+      return SUPPORTED_NETWORKS['avalanche']
+    }
+    case(42161): {
+      return SUPPORTED_NETWORKS['arbitrum']
+    }
+    case(10): {
+      return SUPPORTED_NETWORKS['optimism']
+    }
+    case(250): {
+      return SUPPORTED_NETWORKS['fantom']
+    }
+    default:
+      return {
+        chainId,
+        blockTimeInSeconds: DEFAULTS_BLOCK_TIME_IN_SECONDS
+      }
+  }
+}
+
+const SUPPORTED_NETWORKS: {[key in NetworkName]: BlockchainNetworkConfig} = {
+  "ethereum": {
+    chainId: 1,
+    blockTimeInSeconds: DEFAULTS_BLOCK_TIME_IN_SECONDS
+  },
+  "polygon": {
+    chainId: 137,
+    blockTimeInSeconds: 3 // https://polygonscan.com/chart/blocktime
+  },
+  "binance_smart_chain": {
+    chainId: 56,
+    blockTimeInSeconds: 5 // https://bscscan.com/chart/blocktime
+  },
+  "avalanche": {
+    chainId: 43114,
+    blockTimeInSeconds: 3 // https://avascan.info/
+  },
+  "arbitrum": {
+    chainId: 42161,
+    blockTimeInSeconds: DEFAULTS_BLOCK_TIME_IN_SECONDS
+  },
+  "optimism": {
+    chainId: 10,
+    blockTimeInSeconds: DEFAULTS_BLOCK_TIME_IN_SECONDS
+  },
+  "fantom": {
+    chainId: 250,
+    blockTimeInSeconds: 5 // https://ftmscan.com/chart/blocktime
+  }
+}


### PR DESCRIPTION
Dynamically set polling time when running bot locally. Falls back to a default polling time of 15 seconds. 