### PR TITLE
Adding new info command to give event history of forta bot

### DIFF
--- a/cli/commands/info/index.spec.ts
+++ b/cli/commands/info/index.spec.ts
@@ -28,7 +28,8 @@ describe("info", () => {
     }
 
     const getFromIpfs = jest.fn();
-    const getTransactionReceipt = jest.fn()
+    const getTransactionReceipt = jest.fn();
+    const getLogsFromPolyscan = jest.fn();
 
     const agentRegistryContractAddress = "0x987654";
 
@@ -111,7 +112,8 @@ describe("info", () => {
     const testDaysToScan = (5000.5 * blockTimeInSeconds) / 86000;
 
     beforeAll(() => {
-        info = provideInfo("", args, mockEthersAgentRegistryProvider as any, mockAgentRegistry as any ,agentRegistryContractAddress,getFromIpfs, getTransactionReceipt)
+        console.log(`Topic filters are: ${blockEventTopicFilters.forEach(hash => console.log(`\n ${hash}`))}`)
+        info = provideInfo("", args, mockEthersAgentRegistryProvider as any, mockAgentRegistry as any ,agentRegistryContractAddress,getFromIpfs, getTransactionReceipt,getLogsFromPolyscan)
     })
 
     // Helper methods

--- a/cli/commands/info/index.spec.ts
+++ b/cli/commands/info/index.spec.ts
@@ -1,23 +1,180 @@
+import { Network } from "@ethersproject/networks"
+import { providers } from "ethers"
+import provideInfo from "."
+import { CommandHandler } from "../.."
+import { AgentDescription, AGENT_REGESTRY_EVENT_FRAGMENTS, getTopicHashFromEventName, isRelevantSmartContractEvent, StateChangeContractEvent } from "../../contracts/agent.registry"
+import { getBlockChainNetworkConfig } from "../../utils"
+import { IpfsMetadata } from "../../utils/ipfs/get.from.ipfs"
 
 
 describe("info", () => {
+    let info: CommandHandler
+    const args = {
+        agentId: "0x1234456"
+    }
 
-    it("generates correct topic hash for Transfer contract event", async () => {
+    const mockEthersAgentRegistryProvider = {
+        getBlockNumber: jest.fn(),
+        getBlock: jest.fn(),
+        getNetwork: jest.fn(),
+        getLogs: jest.fn()
+    }
+
+    const mockAgentRegistry = {
+        getAgent: jest.fn(),
+        isEnabled: jest.fn()
+    }
+
+    const getFromIpfs = jest.fn();
+    const getTransactionReceipt = jest.fn()
+
+    const agentRegistryContractAddress = "0x987654";
+
+    const resetMocks = () => {
+        mockEthersAgentRegistryProvider.getBlockNumber.mockReset()
+        mockEthersAgentRegistryProvider.getNetwork.mockReset()
+        mockEthersAgentRegistryProvider.getLogs.mockReset()
+        mockAgentRegistry.getAgent.mockReset()
+        mockAgentRegistry.isEnabled.mockReset()
+        getFromIpfs.mockReset()
+        getTransactionReceipt.mockReset()
+    }
+
+    const testNetwork: Network = {
+        name: "etherum",
+        chainId: 1
+    }
+
+    const mockIpfsManifest = {
+        "from":"0x123456",
+        "name":"Compound Liquidatable Positions Monitor",
+        "agentId":"Compound Liquidatable Positions Monitor",
+        "agentIdHash":"0x3c61101f1d349661298a58ba59a58fbce5a3626c5c7af10b091796969e0d6c59",
+        "version":"0.0.1",
+        "timestamp":"Fri, 20 May 2022 15:54:56 GMT",
+        "imageReference":"bafybeib5kmox5r2wpre3tgkfgfr76tm4qascagmqvod2wcojxrqmgyxfp4@sha256:2fcfede6f821f4f14e745598fd71b2201471517acd345f7b8f0cd424d35b441a",
+        "documentation":"QmQXZvBdZ4eMtCefNXYMRwQ7UJbgW74EqrMv9wS9hoSXV7",
+        "repository":"https://github.com/arbitraryexecution/compound-monitoring/tree/main/liquidation-monitor",
+        "projects":[
+           "compound_v2"
+        ],
+        "chainIds":[
+           1
+        ],
+        "publishedFrom":"Forta Explorer 0.0.2"
+     } as IpfsMetadata
+
+     const mockLogOne: providers.Log = {
+        blockNumber: 1500000,
+        blockHash: "0x2345",
+        transactionIndex: 0,
+        removed: false,
+        address: "0x424",
+        data: "",
+        topics: ["0xb3910705ae5b4ecc20f77ab0d947aafd48ed7328af2294ca08dea714b041d641"],
+        transactionHash: "0x2352",
+        logIndex: 0
+    }
+
+    const mockLogTwo: providers.Log = {
+        blockNumber: 1490000,
+        blockHash: "0x2345",
+        transactionIndex: 0,
+        removed: false,
+        address: "0x424",
+        data: "",
+        topics: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"],
+        transactionHash: "0x235264",
+        logIndex: 0
+    }
+
+    const mockAgentDescription: AgentDescription = {
+        created: true,
+        owner: "0x1458395",
+        metadata: "0x23847"
+    } 
+
+    const blockEventTopicFilters = AGENT_REGESTRY_EVENT_FRAGMENTS
+            .filter(fragment => isRelevantSmartContractEvent(fragment.name))
+            .map(eventFragment => getTopicHashFromEventName(eventFragment.name as StateChangeContractEvent)) as string[];
+
+    beforeEach(() => {
+        resetMocks()
+        defaultMocks(true)
+    })
+
+    const { blockTimeInSeconds } = getBlockChainNetworkConfig(testNetwork.chainId);
+    const testDaysToScan = (5000.5 * blockTimeInSeconds) / 86000;
+
+    beforeAll(() => {
+        info = provideInfo("", args, mockEthersAgentRegistryProvider as any, mockAgentRegistry as any ,agentRegistryContractAddress,getFromIpfs, getTransactionReceipt)
+    })
+
+    // Helper methods
+
+    const defaultMocks = (isBotEnabled: boolean) => {
+        mockAgentRegistry.getAgent.mockReturnValueOnce(mockAgentDescription)
+        mockAgentRegistry.isEnabled.mockReturnValue(isBotEnabled)
+
+        getFromIpfs.mockReturnValueOnce(mockIpfsManifest)
+
+        mockEthersAgentRegistryProvider.getBlockNumber.mockReturnValue(2000000)
+        mockEthersAgentRegistryProvider.getNetwork.mockReturnValue(testNetwork)
+        mockEthersAgentRegistryProvider.getLogs.mockReturnValueOnce(mockLogOne).mockReturnValue(mockLogTwo)
+
+        getTransactionReceipt.mockReturnValue({from: mockIpfsManifest.from, transactionHash: "0x34211"})
+
+        mockEthersAgentRegistryProvider.getBlock.mockReturnValueOnce({timestamp: 1654440565}).mockReturnValue({timestamp: 1654430565})
+    }
+
+    it("fetches the current state of a deployed bot", async () => {
+        await info(testDaysToScan)
+
+        expect(mockAgentRegistry.isEnabled).toHaveBeenCalledWith(args.agentId)
+    })
+
+    it("fetches the most recent ipfs metadata of a deployed bot", async () => {
+        await info(testDaysToScan)
+
+        expect(getFromIpfs).toHaveBeenCalledWith(mockAgentDescription.metadata)
+    })
+
+    it("filters contract logs by relevent topics", async () => {
+        await info(testDaysToScan)
+
+        expect(mockEthersAgentRegistryProvider.getLogs).toHaveBeenCalledWith({
+            address: expect.anything(),
+            fromBlock: expect.anything(),
+            toBlock: expect.anything(),
+            topics: [[...blockEventTopicFilters], null]
+        })
+    })
+
+    it.skip("fecthes 5 different block ranges of block logs in parallel", async () => {
 
     })
 
-    describe("Agent Registry ABI Interface", () => {
+    it.skip("prints a Bot Created event to console", async () => {
 
-        it("correct topic hash for Transfer contract event", async () => {
-            
-        })
+    })
 
-        it("correct topic hash for Agent Updated contract event", async () => {
-            
-        })
+    it.skip("prints a Bot Updated event to console", async () => {
 
-        it("correct topic hash for AgentEnabled contract event", async () => {
-            
-        })
+    })
+
+    it.skip("prints a Bot Enabled event to console", async () => {
+
+    })
+
+    it.skip("prints block logs in descending order (most recent logs on top) to console", async () => {
+
+    })
+
+    it.skip("does not print anything if no logs found for agentId", async () => {
+
+    })
+
+    it.skip("does not print anything if no relevant events found for agentId", async () => {
+
     })
 })

--- a/cli/commands/info/index.spec.ts
+++ b/cli/commands/info/index.spec.ts
@@ -2,7 +2,7 @@ import { Network } from "@ethersproject/networks"
 import { providers } from "ethers"
 import provideInfo from "."
 import { CommandHandler } from "../.."
-import { AgentDescription, AGENT_REGESTRY_EVENT_FRAGMENTS, getTopicHashFromEventName, isRelevantSmartContractEvent, StateChangeContractEvent } from "../../contracts/agent.registry"
+import { AgentDescription, AGENT_REGISTRY_EVENT_FRAGMENTS, getTopicHashFromEventName, isRelevantSmartContractEvent, StateChangeContractEvent } from "../../contracts/agent.registry"
 import { getBlockChainNetworkConfig } from "../../utils"
 import { IpfsMetadata } from "../../utils/ipfs/get.from.ipfs"
 
@@ -98,7 +98,7 @@ describe("info", () => {
     } 
 
     // Helper variables and test callbacks
-    const blockEventTopicFilters = AGENT_REGESTRY_EVENT_FRAGMENTS
+    const blockEventTopicFilters = AGENT_REGISTRY_EVENT_FRAGMENTS
             .filter(fragment => isRelevantSmartContractEvent(fragment.name))
             .map(eventFragment => getTopicHashFromEventName(eventFragment.name as StateChangeContractEvent)) as string[];
 

--- a/cli/commands/info/index.spec.ts
+++ b/cli/commands/info/index.spec.ts
@@ -4,7 +4,7 @@ import provideInfo from "."
 import { CommandHandler } from "../.."
 import { AgentDescription, AGENT_REGISTRY_EVENT_FRAGMENTS, getTopicHashFromEventName, isRelevantSmartContractEvent, StateChangeContractEvent } from "../../contracts/agent.registry"
 import { getBlockChainNetworkConfig } from "../../utils"
-import { IpfsMetadata } from "../../utils/ipfs/get.from.ipfs"
+import { IpfsData, IpfsManifestData } from "../../utils/ipfs/get.from.ipfs"
 import { PolyscanLog } from "../../utils/polyscan/get.logs.from.polyscan"
 
 
@@ -48,23 +48,25 @@ describe("info", () => {
     }
 
     const mockIpfsManifest = {
-        "from":"0x123456",
-        "name":"Compound Liquidatable Positions Monitor",
-        "agentId":"Compound Liquidatable Positions Monitor",
-        "agentIdHash":"0x3c61101f1d349661298a58ba59a58fbce5a3626c5c7af10b091796969e0d6c59",
-        "version":"0.0.1",
-        "timestamp":"Fri, 20 May 2022 15:54:56 GMT",
-        "imageReference":"bafybeib5kmox5r2wpre3tgkfgfr76tm4qascagmqvod2wcojxrqmgyxfp4@sha256:2fcfede6f821f4f14e745598fd71b2201471517acd345f7b8f0cd424d35b441a",
-        "documentation":"QmQXZvBdZ4eMtCefNXYMRwQ7UJbgW74EqrMv9wS9hoSXV7",
-        "repository":"https://github.com/arbitraryexecution/compound-monitoring/tree/main/liquidation-monitor",
-        "projects":[
-           "compound_v2"
-        ],
-        "chainIds":[
-           1
-        ],
-        "publishedFrom":"Forta Explorer 0.0.2"
-     } as IpfsMetadata
+        "manifest":{
+            "from":"0x123456",
+            "name":"Compound Liquidatable Positions Monitor",
+            "agentId":"Compound Liquidatable Positions Monitor",
+            "agentIdHash":"0x3c61101f1d349661298a58ba59a58fbce5a3626c5c7af10b091796969e0d6c59",
+            "version":"0.0.1",
+            "timestamp":"Fri, 20 May 2022 15:54:56 GMT",
+            "imageReference":"bafybeib5kmox5r2wpre3tgkfgfr76tm4qascagmqvod2wcojxrqmgyxfp4@sha256:2fcfede6f821f4f14e745598fd71b2201471517acd345f7b8f0cd424d35b441a",
+            "documentation":"QmQXZvBdZ4eMtCefNXYMRwQ7UJbgW74EqrMv9wS9hoSXV7",
+            "repository":"https://github.com/arbitraryexecution/compound-monitoring/tree/main/liquidation-monitor",
+            "projects":[
+               "compound_v2"
+            ],
+            "chainIds":[
+               1
+            ],
+            "publishedFrom":"Forta Explorer 0.0.2"
+         } as IpfsManifestData
+     } as IpfsData
 
      const mockLogOne: PolyscanLog = {
         timeStamp: 1500000,

--- a/cli/commands/info/index.spec.ts
+++ b/cli/commands/info/index.spec.ts
@@ -1,0 +1,23 @@
+
+
+describe("info", () => {
+
+    it("generates correct topic hash for Transfer contract event", async () => {
+
+    })
+
+    describe("Agent Registry ABI Interface", () => {
+
+        it("correct topic hash for Transfer contract event", async () => {
+            
+        })
+
+        it("correct topic hash for Agent Updated contract event", async () => {
+            
+        })
+
+        it("correct topic hash for AgentEnabled contract event", async () => {
+            
+        })
+    })
+})

--- a/cli/commands/info/index.ts
+++ b/cli/commands/info/index.ts
@@ -20,7 +20,6 @@ export default function provideInfo(
     agentRegistry: AgentRegistry,
     agentRegistryContractAddress: string,
     getFromIpfs: GetFromIpfs,
-    getTransactionReceipt: GetTransactionReceipt,
     getLogsFromPolyscan: GetLogsFromPolyscan
 ): CommandHandler {
     assertExists(args, 'args')
@@ -28,7 +27,7 @@ export default function provideInfo(
     assertExists(agentRegistry, 'agentRegistry')
     assertExists(agentRegistryContractAddress, 'agentRegistryContractAddress')
     assertExists(getFromIpfs, 'getFromIpfs')
-    assertExists(getTransactionReceipt, 'getTransactionReceipt')
+    assertExists(getLogsFromPolyscan, 'getLogsFromPolyscan')
 
     return async function info() {
         const finalAgentId = args.agentId ? args.agentId : agentId;

--- a/cli/commands/info/index.ts
+++ b/cli/commands/info/index.ts
@@ -74,7 +74,7 @@ export default function provideInfo(
 
         for (let log of filteredLogs) {
             const eventName = getEventNameFromTopicHash(log.topics[0]);
-            console.log(` ${formatDate(new Date(log.timeStamp * 1000))} ${formatEventName(eventName)} by ${ipfsData.from} (https://polygonscan.com/tx/${log.transactionHash})\n \n`)
+            console.log(` [${formatDate(new Date(log.timeStamp * 1000))}] ${formatEventName(eventName)} by ${ipfsData.from} (https://polygonscan.com/tx/${log.transactionHash})\n`)
         }
     }
 }
@@ -88,7 +88,7 @@ export const formatIpfsData = (data: IpfsManifestData, isBotEnabled: boolean) =>
         owner: data.from,
         image: data.imageReference,
         publishedFrom: data.publishedFrom,
-        timestamp: data.timestamp,
+        timestamp: formatDate(new Date(data.timestamp)),
         documentation: ` https://ipfs.io/ipfs/${data.documentation}`
     }
 }
@@ -109,9 +109,10 @@ const formatEventName = (eventName: string): string => {
 }
 
 const formatDate = (date: Date): string => {
-    const monthFormatter = new Intl.DateTimeFormat('default', {month: 'short'})
+    const timeFormatter = new Intl.DateTimeFormat('default', {hour: 'numeric', minute: '2-digit', second: '2-digit', timeZoneName: 'short', hour12: false})
+    const monthFormatter = new Intl.DateTimeFormat('default', {month: 'short', year: "numeric"})
     const dayFormatter = new Intl.DateTimeFormat('default', {day: '2-digit' })
-    return `[${dayFormatter.format(date)} ${monthFormatter.format(date)} ${date.toTimeString()}]`
+    return `${dayFormatter.format(date)} ${monthFormatter.format(date)} ${timeFormatter.format(date)}`
 }
 
 const filterSimultaneousEventsOnBotCreation = (logs: PolyscanLog[]): PolyscanLog[] => {

--- a/cli/commands/info/index.ts
+++ b/cli/commands/info/index.ts
@@ -12,7 +12,7 @@ import { GetTransactionReceipt } from "../../utils/get.transaction.receipt";
 import { flatten } from "lodash";
 
 const SECONDS_IN_DAY = 86000;
-const DAYS_TO_SCAN = 30;
+const DEFAULT_DAYS_TO_SCAN = 30;
 
 export default function provideInfo(
     agentId: string,
@@ -25,7 +25,7 @@ export default function provideInfo(
 ): CommandHandler {
     assertExists(getFromIpfs, 'getFromIpfs')
 
-    return async function info() {
+    return async function info(daysToScan = DEFAULT_DAYS_TO_SCAN) {
         const finalAgentId = args.agentId ? args.agentId : agentId;
 
         assertIsNonEmptyString(finalAgentId, 'agentId');
@@ -38,7 +38,7 @@ export default function provideInfo(
         const ipfsData = await getFromIpfs(ipfsMetaHash)
         printIpfsMetaData(ipfsData,currentState)
 
-        console.log(`Recent Activity (Last ${DAYS_TO_SCAN} days): \n`);
+        console.log(`Recent Activity (Last ${daysToScan} days): \n`);
 
         const blockEventTopicFilters = AGENT_REGESTRY_EVENT_FRAGMENTS
             .filter(fragment => isRelevantSmartContractEvent(fragment.name))
@@ -50,7 +50,7 @@ export default function provideInfo(
         const { chainId } = network;
         const { blockTimeInSeconds } = getBlockChainNetworkConfig(chainId);
 
-        const endingBlock = Math.floor(latestBlockNumber - ((DAYS_TO_SCAN * SECONDS_IN_DAY)/(blockTimeInSeconds)));
+        const endingBlock = Math.floor(latestBlockNumber - ((daysToScan * SECONDS_IN_DAY)/(blockTimeInSeconds)));
 
         const increment = 1000;
         let startingBlock = latestBlockNumber - (increment * 5);

--- a/cli/commands/info/index.ts
+++ b/cli/commands/info/index.ts
@@ -7,8 +7,9 @@ import AgentRegistry,
   StateChangeContractEvent } from "../../contracts/agent.registry";
 import { assertExists, assertIsNonEmptyString, getBlockChainNetworkConfig } from "../../utils";
 import { GetFromIpfs, IpfsMetadata } from "../../utils/ipfs/get.from.ipfs";
-import { ethers, providers } from "ethers";
+import { providers } from "ethers";
 import { GetTransactionReceipt } from "../../utils/get.transaction.receipt";
+import { flatten } from "lodash";
 
 const SECONDS_IN_DAY = 86000;
 const DAYS_TO_SCAN = 30;
@@ -37,7 +38,7 @@ export default function provideInfo(
         const ipfsData = await getFromIpfs(ipfsMetaHash)
         printIpfsMetaData(ipfsData)
 
-        console.log(`Recent Activity: \n`);
+        console.log(`Recent Activity (Last ${DAYS_TO_SCAN} days): \n`);
 
         const blockEventTopicFilters = AGENT_REGESTRY_EVENT_FRAGMENTS
             .filter(fragment => isRelevantSmartContractEvent(fragment.name))
@@ -50,30 +51,43 @@ export default function provideInfo(
         const { blockTimeInSeconds } = getBlockChainNetworkConfig(chainId);
 
         const endingBlock = Math.floor(latestBlockNumber - ((DAYS_TO_SCAN * SECONDS_IN_DAY)/(blockTimeInSeconds)));
-        let startingBlock = latestBlockNumber - 500;
-        
-        while(startingBlock > endingBlock) {
-            const toBlock = startingBlock + 500;
-            //console.log(`Fetching logs from block: ${startingBlock} to block: ${toBlock}`)
-            const logs =  await ethersAgentRegistryProvider.getLogs({
+
+        const increment = 1000;
+        let startingBlock = latestBlockNumber - (increment * 5);
+
+        const getAgentLogs = async (startBlock: number, endBlock: number) => {
+            return await ethersAgentRegistryProvider.getLogs({
                 address: agentRegistryContractAddress,
-                fromBlock: startingBlock,
-                toBlock: toBlock,
+                fromBlock: startBlock,
+                toBlock: endBlock,
                 topics: [[...blockEventTopicFilters], null] // This assumes that each smart contract event is indexed so that the first topic is always an event of interest
             });
+        }
+        
+        while(startingBlock > endingBlock) {
+            
+            // Get logs in parallel from 5 diffrent block ranges
+            const response = (await Promise.all([
+                getAgentLogs(startingBlock, startingBlock + increment), 
+                getAgentLogs(startingBlock + increment + 1, startingBlock + (increment * 2)),
+                getAgentLogs(startingBlock + (2 * increment) + 1, startingBlock + (increment * 3)),
+                getAgentLogs(startingBlock + (3 * increment) + 1, startingBlock + (increment * 4)),
+                getAgentLogs(startingBlock + (4 * increment) + 1, startingBlock + (increment * 5))
+            ]))
 
+            const logs =  flatten(response)
 
             for (let log of logs) {
                 const transaction = await getTransactionReceipt(log.transactionHash, true);
 
                 if(transaction.from.toLowerCase() === ipfsData.from.toLowerCase()) {
                     const block = await ethersAgentRegistryProvider.getBlock(log.blockNumber)
-                    const eventName = getEventNameFromTopicHash(log.topics[0]).name;
-                    console.log(` - ${eventName} by ${ipfsData.from} on ${new Date(block.timestamp * 1000)} (https://polygonscan.com/tx/${transaction.transactionHash}\n \n`)
+                    const eventName = getEventNameFromTopicHash(log.topics[0]);
+                    console.log(` - ${eventName} by ${ipfsData.from} on ${new Date(block.timestamp * 1000)} (https://polygonscan.com/tx/${transaction.transactionHash})\n \n`)
                 }
             }
 
-            startingBlock -= 501;
+            startingBlock -= (increment * 5) + 1;
         }
     }
 }

--- a/cli/commands/info/index.ts
+++ b/cli/commands/info/index.ts
@@ -23,7 +23,12 @@ export default function provideInfo(
     getFromIpfs: GetFromIpfs,
     getTransactionReceipt: GetTransactionReceipt,
 ): CommandHandler {
+    assertExists(args, 'args')
+    assertExists(ethersAgentRegistryProvider, 'ethersAgentRegistryProvider')
+    assertExists(agentRegistry, 'agentRegistry')
+    assertExists(agentRegistryContractAddress, 'agentRegistryContractAddress')
     assertExists(getFromIpfs, 'getFromIpfs')
+    assertExists(getTransactionReceipt, 'getTransactionReceipt')
 
     return async function info(daysToScan = DEFAULT_DAYS_TO_SCAN) {
         const finalAgentId = args.agentId ? args.agentId : agentId;
@@ -50,6 +55,7 @@ export default function provideInfo(
         const { chainId } = network;
         const { blockTimeInSeconds } = getBlockChainNetworkConfig(chainId);
 
+        console.log(`Days to scan is: ${daysToScan}, Block to subtract is: ${(daysToScan * SECONDS_IN_DAY)/(blockTimeInSeconds)}`)
         const endingBlock = Math.floor(latestBlockNumber - ((daysToScan * SECONDS_IN_DAY)/(blockTimeInSeconds)));
 
         const increment = 1000;
@@ -64,6 +70,7 @@ export default function provideInfo(
             });
         }
         
+        console.log(`Starting block: ${startingBlock} and ending Block: ${endingBlock}`)
         while(startingBlock > endingBlock) {
             
             // Get logs in parallel from 5 diffrent block ranges
@@ -75,7 +82,7 @@ export default function provideInfo(
                 getAgentLogs(startingBlock + (4 * increment) + 1, startingBlock + (increment * 5))
             ]))
 
-            const logs =  flatten(response)
+            const logs = flatten(response)
 
             for (let log of logs) {
                 const transaction = await getTransactionReceipt(log.transactionHash, true);

--- a/cli/commands/info/index.ts
+++ b/cli/commands/info/index.ts
@@ -55,7 +55,6 @@ export default function provideInfo(
         const { chainId } = network;
         const { blockTimeInSeconds } = getBlockChainNetworkConfig(chainId);
 
-        console.log(`Days to scan is: ${daysToScan}, Block to subtract is: ${(daysToScan * SECONDS_IN_DAY)/(blockTimeInSeconds)}`)
         const endingBlock = Math.floor(latestBlockNumber - ((daysToScan * SECONDS_IN_DAY)/(blockTimeInSeconds)));
 
         const increment = 1000;
@@ -70,7 +69,6 @@ export default function provideInfo(
             });
         }
         
-        console.log(`Starting block: ${startingBlock} and ending Block: ${endingBlock}`)
         while(startingBlock > endingBlock) {
             
             // Get logs in parallel from 5 diffrent block ranges

--- a/cli/commands/info/index.ts
+++ b/cli/commands/info/index.ts
@@ -1,0 +1,85 @@
+import { CommandHandler } from "../..";
+import AgentRegistry, 
+{ AGENT_REGESTRY_EVENT_FRAGMENTS, 
+  getEventNameFromTopicHash, 
+  getTopicHashFromEventName, 
+  isRelevantSmartContractEvent, 
+  StateChangeContractEvent } from "../../contracts/agent.registry";
+import { assertExists, assertIsNonEmptyString, getBlockChainNetworkConfig } from "../../utils";
+import { GetFromIpfs, IpfsMetadata } from "../../utils/ipfs/get.from.ipfs";
+import { ethers, providers } from "ethers";
+import { GetTransactionReceipt } from "../../utils/get.transaction.receipt";
+
+const SECONDS_IN_DAY = 86000;
+const DAYS_TO_SCAN = 30;
+
+export default function provideInfo(
+    agentId: string,
+    args: any,
+    ethersAgentRegistryProvider: providers.JsonRpcProvider,
+    agentRegistry: AgentRegistry,
+    agentRegistryContractAddress: string,
+    getFromIpfs: GetFromIpfs,
+    getTransactionReceipt: GetTransactionReceipt,
+): CommandHandler {
+    assertExists(getFromIpfs, 'getFromIpfs')
+
+    return async function info() {
+        const finalAgentId = args.agentId ? args.agentId : agentId;
+
+        assertIsNonEmptyString(finalAgentId, 'agentId');
+
+        const agent = await agentRegistry.getAgent(finalAgentId);
+        const currentState = await agentRegistry.isEnabled(finalAgentId)
+        const ipfsMetaHash = agent.metadata;
+
+
+        const ipfsData = await getFromIpfs(ipfsMetaHash)
+        printIpfsMetaData(ipfsData)
+
+        console.log(`Recent Activity: \n`);
+
+        const blockEventTopicFilters = AGENT_REGESTRY_EVENT_FRAGMENTS
+            .filter(fragment => isRelevantSmartContractEvent(fragment.name))
+            .map(eventFragment => getTopicHashFromEventName(eventFragment.name as StateChangeContractEvent)) as string[];
+
+        const latestBlockNumber = await ethersAgentRegistryProvider.getBlockNumber();
+
+        const network = await ethersAgentRegistryProvider.getNetwork();
+        const { chainId } = network;
+        const { blockTimeInSeconds } = getBlockChainNetworkConfig(chainId);
+
+        const endingBlock = Math.floor(latestBlockNumber - ((DAYS_TO_SCAN * SECONDS_IN_DAY)/(blockTimeInSeconds)));
+        let startingBlock = latestBlockNumber - 500;
+        
+        while(startingBlock > endingBlock) {
+            const toBlock = startingBlock + 500;
+            //console.log(`Fetching logs from block: ${startingBlock} to block: ${toBlock}`)
+            const logs =  await ethersAgentRegistryProvider.getLogs({
+                address: agentRegistryContractAddress,
+                fromBlock: startingBlock,
+                toBlock: toBlock,
+                topics: [[...blockEventTopicFilters], null] // This assumes that each smart contract event is indexed so that the first topic is always an event of interest
+            });
+
+
+            for (let log of logs) {
+                const transaction = await getTransactionReceipt(log.transactionHash, true);
+
+                if(transaction.from.toLowerCase() === ipfsData.from.toLowerCase()) {
+                    const block = await ethersAgentRegistryProvider.getBlock(log.blockNumber)
+                    const eventName = getEventNameFromTopicHash(log.topics[0]).name;
+                    console.log(` - ${eventName} by ${ipfsData.from} on ${new Date(block.timestamp * 1000)} (https://polygonscan.com/tx/${transaction.transactionHash}\n \n`)
+                }
+            }
+
+            startingBlock -= 501;
+        }
+    }
+}
+
+const printIpfsMetaData = (ipfsData: IpfsMetadata) => {
+    console.log("\n")
+    Object.entries(ipfsData).forEach(([key, value]) => console.log(`${key}: ${value}`))
+}
+

--- a/cli/contracts/agent.registry.ts
+++ b/cli/contracts/agent.registry.ts
@@ -32,8 +32,15 @@ export const getTopicHashFromEventName = (eventName: StateChangeContractEvent): 
   return;
 }
 
-export const getEventNameFromTopicHash = (topicHash: string): EventFragment => {
-  return AGENT_REGISTRY_ABI.getEvent(topicHash)
+export const getEventNameFromTopicHash = (topicHash: string): string => {
+  const eventFragment = AGENT_REGISTRY_ABI.getEvent(topicHash);
+  const name = eventFragment.name;
+
+  if(name === "Transfer") {
+    return "Create Agent";
+  }
+
+  return name;
 }
 
 export default class AgentRegistry {

--- a/cli/contracts/agent.registry.ts
+++ b/cli/contracts/agent.registry.ts
@@ -16,7 +16,7 @@ const FALLBACK_DISABLE_AGENT_GAS_LIMIT = BigNumber.from(70_000)
 }
 
 export const AGENT_REGISTRY_ABI = new Interface(AgentRegistryAbi);
-export const AGENT_REGESTRY_EVENT_FRAGMENTS = AGENT_REGISTRY_ABI.fragments.filter(fragment => fragment.type === "event") as EventFragment[];
+export const AGENT_REGISTRY_EVENT_FRAGMENTS = AGENT_REGISTRY_ABI.fragments.filter(fragment => fragment.type === "event") as EventFragment[];
 
 const RELEVANT_SMART_CONTRACT_EVENTS = ["AgentEnabled", "AgentUpdated", "Transfer"] as const;
 export type StateChangeContractEvent = (typeof RELEVANT_SMART_CONTRACT_EVENTS)[number];
@@ -24,7 +24,7 @@ export const isRelevantSmartContractEvent = (str: any): str is StateChangeContra
 
 
 export const getTopicHashFromEventName = (eventName: StateChangeContractEvent): string | undefined => {
-  const fragment = AGENT_REGESTRY_EVENT_FRAGMENTS.find(fragment => fragment.name === eventName);
+  const fragment = AGENT_REGISTRY_EVENT_FRAGMENTS.find(fragment => fragment.name === eventName);
 
   if(fragment){
       return AGENT_REGISTRY_ABI.getEventTopic(fragment);

--- a/cli/contracts/agent.registry.ts
+++ b/cli/contracts/agent.registry.ts
@@ -1,4 +1,5 @@
 import { BigNumber, ethers, providers, Wallet } from "ethers"
+import { EventFragment, Interface } from "ethers/lib/utils"
 import AgentRegistryAbi from "./agent.registry.abi.json"
 
 const GAS_MULTIPLIER = 1.15
@@ -12,6 +13,27 @@ type AgentDescription = {
   created: boolean;
   owner: string;
   metadata: string;
+}
+
+export const AGENT_REGISTRY_ABI = new Interface(AgentRegistryAbi);
+export const AGENT_REGESTRY_EVENT_FRAGMENTS = AGENT_REGISTRY_ABI.fragments.filter(fragment => fragment.type === "event") as EventFragment[];
+
+const RELEVANT_SMART_CONTRACT_EVENTS = ["AgentEnabled", "AgentUpdated", "Transfer"] as const;
+export type StateChangeContractEvent = (typeof RELEVANT_SMART_CONTRACT_EVENTS)[number];
+export const isRelevantSmartContractEvent = (str: any): str is StateChangeContractEvent => RELEVANT_SMART_CONTRACT_EVENTS.includes(str);
+
+
+export const getTopicHashFromEventName = (eventName: StateChangeContractEvent): string | undefined => {
+  const fragment = AGENT_REGESTRY_EVENT_FRAGMENTS.find(fragment => fragment.name === eventName);
+
+  if(fragment){
+      return AGENT_REGISTRY_ABI.getEventTopic(fragment);
+  }
+  return;
+}
+
+export const getEventNameFromTopicHash = (topicHash: string): EventFragment => {
+  return AGENT_REGISTRY_ABI.getEvent(topicHash)
 }
 
 export default class AgentRegistry {

--- a/cli/contracts/agent.registry.ts
+++ b/cli/contracts/agent.registry.ts
@@ -9,7 +9,7 @@ const FALLBACK_UPDATE_AGENT_GAS_LIMIT = BigNumber.from(95_000)
 const FALLBACK_ENABLE_AGENT_GAS_LIMIT = BigNumber.from(55_000)
 const FALLBACK_DISABLE_AGENT_GAS_LIMIT = BigNumber.from(70_000)
 
-type AgentDescription = {
+ export type AgentDescription = {
   created: boolean;
   owner: string;
   metadata: string;

--- a/cli/contracts/agent.registry.ts
+++ b/cli/contracts/agent.registry.ts
@@ -34,12 +34,7 @@ export const getTopicHashFromEventName = (eventName: StateChangeContractEvent): 
 
 export const getEventNameFromTopicHash = (topicHash: string): string => {
   const eventFragment = AGENT_REGISTRY_ABI.getEvent(topicHash);
-  const name = eventFragment.name;
-
-  if(name === "Transfer") {
-    return "Create Agent";
-  }
-
+  let name = eventFragment.name;
   return name;
 }
 

--- a/cli/di.container.ts
+++ b/cli/di.container.ts
@@ -50,6 +50,8 @@ import provideInitConfig from './utils/init.config'
 import provideGetLogsForBlock from './utils/get.logs.for.block'
 import { provideGetAgentLogs } from './utils/get.agent.logs'
 import provideLogs from './commands/logs'
+import provideInfo from './commands/info'
+import provideGetFromIpfs from './utils/ipfs/get.from.ipfs'
 
 export default function configureContainer(args: any = {}) {
   const container = createContainer({ injectionMode: InjectionMode.CLASSIC });
@@ -92,6 +94,7 @@ export default function configureContainer(args: any = {}) {
     }).singleton(),
 
     init: asFunction(provideInit),
+    info: asFunction(provideInfo),
     run: asFunction(provideRun),
     logs: asFunction(provideLogs),
     publish: asFunction(providePublish),
@@ -177,6 +180,7 @@ export default function configureContainer(args: any = {}) {
     createKeyfile: asFunction(provideCreateKeyfile),
     listKeyfiles: asFunction(provideListKeyfiles),
     addToIpfs: asFunction(provideAddToIpfs),
+    getFromIpfs: asFunction(provideGetFromIpfs),
     appendToFile: asFunction(provideAppendToFile),
     initKeystore: asFunction(provideInitKeystore),
     initKeyfile: asFunction(provideInitKeyfile),

--- a/cli/di.container.ts
+++ b/cli/di.container.ts
@@ -52,6 +52,7 @@ import { provideGetAgentLogs } from './utils/get.agent.logs'
 import provideLogs from './commands/logs'
 import provideInfo from './commands/info'
 import provideGetFromIpfs from './utils/ipfs/get.from.ipfs'
+import provideGetLogsFromPolyscan from './utils/polyscan/get.logs.from.polyscan'
 
 export default function configureContainer(args: any = {}) {
   const container = createContainer({ injectionMode: InjectionMode.CLASSIC });
@@ -181,6 +182,7 @@ export default function configureContainer(args: any = {}) {
     listKeyfiles: asFunction(provideListKeyfiles),
     addToIpfs: asFunction(provideAddToIpfs),
     getFromIpfs: asFunction(provideGetFromIpfs),
+    getLogsFromPolyscan: asFunction(provideGetLogsFromPolyscan),
     appendToFile: asFunction(provideAppendToFile),
     initKeystore: asFunction(provideInitKeystore),
     initKeyfile: asFunction(provideInitKeyfile),
@@ -194,6 +196,7 @@ export default function configureContainer(args: any = {}) {
     getTraceData: asFunction(provideGetTraceData),
     getAgentLogs: asFunction(provideGetAgentLogs),
     fortaApiUrl: asValue('https://api.forta.network'),
+    polyscanApiUrl: asValue('https://api.polygonscan.com/api'),
     traceRpcUrl: asFunction((fortaConfig: FortaConfig) => {
       return fortaConfig.traceRpcUrl
     }).singleton(),

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -27,10 +27,10 @@ yargs
     },
     (cliArgs: any) => executeCommand("init", cliArgs)
   )
-  .command('info', 'Inspect state of the Forta Agent', 
+  .command('info', 'Inspect state of the Forta Bot', 
     (yargs: Argv) => {
       yargs.option('agentId', {
-        description: 'Agent id to retrieve logs for. Default value is this agent',
+        description: 'Bot id to retrieve information for. Default value is this agent',
         type: 'string'
       })
     },

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -2,7 +2,7 @@
 import yargs, { Argv } from 'yargs';
 import configureContainer from './di.container';
 
-type CommandName = "init" | "run" | "publish" | "push" | "disable" | "enable" | "keyfile" | "logs"
+type CommandName = "init" | "run" | "publish" | "push" | "disable" | "enable" | "keyfile" | "logs" | "info"
 export type CommandHandler = (args?: any) => Promise<void>
 
 async function executeCommand(cliCommandName: CommandName, cliArgs: any) {
@@ -26,6 +26,15 @@ yargs
       })
     },
     (cliArgs: any) => executeCommand("init", cliArgs)
+  )
+  .command('info', 'Inspect state of the Forta Agent', 
+    (yargs: Argv) => {
+      yargs.option('agentId', {
+        description: 'Agent id to retrieve logs for. Default value is this agent',
+        type: 'string'
+      })
+    },
+    (cliArgs: any) => executeCommand("info", cliArgs)
   )
   .command('run', 'Run the Forta Agent with latest blockchain data',
     (yargs: Argv) => {

--- a/cli/utils/get.transaction.receipt.spec.ts
+++ b/cli/utils/get.transaction.receipt.spec.ts
@@ -5,9 +5,6 @@ describe("getTransactionReceipt", () => {
   const mockEthersProvider = {
     send: jest.fn()
   } as any
-  const mockRegistryEthersProvider = {
-    send: jest.fn()
-  } as any
   const mockCache = {
     getKey: jest.fn(),
     setKey: jest.fn()
@@ -20,7 +17,7 @@ describe("getTransactionReceipt", () => {
   }
 
   beforeAll(() => {
-    getTransactionReceipt = provideGetTransactionReceipt(mockEthersProvider, mockRegistryEthersProvider, mockCache)
+    getTransactionReceipt = provideGetTransactionReceipt(mockEthersProvider, mockCache)
   })
 
   beforeEach(() => resetMocks())
@@ -51,22 +48,6 @@ describe("getTransactionReceipt", () => {
     expect(mockCache.getKey).toHaveBeenCalledWith(mockTxHash.toLowerCase())
     expect(mockEthersProvider.send).toHaveBeenCalledTimes(1)
     expect(mockEthersProvider.send).toHaveBeenCalledWith('eth_getTransactionReceipt', [mockTxHash])
-    expect(mockCache.setKey).toHaveBeenCalledTimes(1)
-    expect(mockCache.setKey).toHaveBeenCalledWith(mockTxHash.toLowerCase(), mockReceipt)
-  })
-
-  it("invokes eth_getTransactionReceipt jsonrpc method on agent registry provider and returns receipt", async () => {
-    const mockTxHash = "0x123"
-    const mockReceipt = { hash: mockTxHash, blockNumber: 123 }
-    mockRegistryEthersProvider.send.mockReturnValueOnce(mockReceipt)
-
-    const receipt = await getTransactionReceipt(mockTxHash, true)
-
-    expect(receipt).toStrictEqual(mockReceipt)
-    expect(mockCache.getKey).toHaveBeenCalledTimes(1)
-    expect(mockCache.getKey).toHaveBeenCalledWith(mockTxHash.toLowerCase())
-    expect(mockRegistryEthersProvider.send).toHaveBeenCalledTimes(1)
-    expect(mockRegistryEthersProvider.send).toHaveBeenCalledWith('eth_getTransactionReceipt', [mockTxHash])
     expect(mockCache.setKey).toHaveBeenCalledTimes(1)
     expect(mockCache.setKey).toHaveBeenCalledWith(mockTxHash.toLowerCase(), mockReceipt)
   })

--- a/cli/utils/get.transaction.receipt.spec.ts
+++ b/cli/utils/get.transaction.receipt.spec.ts
@@ -5,6 +5,9 @@ describe("getTransactionReceipt", () => {
   const mockEthersProvider = {
     send: jest.fn()
   } as any
+  const mockRegistryEthersProvider = {
+    send: jest.fn()
+  } as any
   const mockCache = {
     getKey: jest.fn(),
     setKey: jest.fn()
@@ -17,7 +20,7 @@ describe("getTransactionReceipt", () => {
   }
 
   beforeAll(() => {
-    getTransactionReceipt = provideGetTransactionReceipt(mockEthersProvider, mockCache)
+    getTransactionReceipt = provideGetTransactionReceipt(mockEthersProvider, mockRegistryEthersProvider, mockCache)
   })
 
   beforeEach(() => resetMocks())

--- a/cli/utils/get.transaction.receipt.spec.ts
+++ b/cli/utils/get.transaction.receipt.spec.ts
@@ -39,7 +39,7 @@ describe("getTransactionReceipt", () => {
     expect(mockCache.setKey).toHaveBeenCalledTimes(0)
   })
 
-  it("invokes eth_getTransactionReceipt jsonrpc method and returns receipt", async () => {
+  it("invokes eth_getTransactionReceipt jsonrpc method on ethers provider and returns receipt", async () => {
     const mockTxHash = "0x123"
     const mockReceipt = { hash: mockTxHash, blockNumber: 123 }
     mockEthersProvider.send.mockReturnValueOnce(mockReceipt)
@@ -51,6 +51,22 @@ describe("getTransactionReceipt", () => {
     expect(mockCache.getKey).toHaveBeenCalledWith(mockTxHash.toLowerCase())
     expect(mockEthersProvider.send).toHaveBeenCalledTimes(1)
     expect(mockEthersProvider.send).toHaveBeenCalledWith('eth_getTransactionReceipt', [mockTxHash])
+    expect(mockCache.setKey).toHaveBeenCalledTimes(1)
+    expect(mockCache.setKey).toHaveBeenCalledWith(mockTxHash.toLowerCase(), mockReceipt)
+  })
+
+  it("invokes eth_getTransactionReceipt jsonrpc method on agent registry provider and returns receipt", async () => {
+    const mockTxHash = "0x123"
+    const mockReceipt = { hash: mockTxHash, blockNumber: 123 }
+    mockRegistryEthersProvider.send.mockReturnValueOnce(mockReceipt)
+
+    const receipt = await getTransactionReceipt(mockTxHash, true)
+
+    expect(receipt).toStrictEqual(mockReceipt)
+    expect(mockCache.getKey).toHaveBeenCalledTimes(1)
+    expect(mockCache.getKey).toHaveBeenCalledWith(mockTxHash.toLowerCase())
+    expect(mockRegistryEthersProvider.send).toHaveBeenCalledTimes(1)
+    expect(mockRegistryEthersProvider.send).toHaveBeenCalledWith('eth_getTransactionReceipt', [mockTxHash])
     expect(mockCache.setKey).toHaveBeenCalledTimes(1)
     expect(mockCache.setKey).toHaveBeenCalledWith(mockTxHash.toLowerCase(), mockReceipt)
   })

--- a/cli/utils/get.transaction.receipt.ts
+++ b/cli/utils/get.transaction.receipt.ts
@@ -18,26 +18,22 @@ export type JsonRpcTransactionReceipt = Omit<Receipt, 'status' | 'blockNumber' |
 }
 
 // returns a transaction receipt as provided by the "eth_getTransactionReceipt" json-rpc method
-export type GetTransactionReceipt = (txHash: string,  onAgentRegistry?: boolean) => Promise<JsonRpcTransactionReceipt>
+export type GetTransactionReceipt = (txHash: string) => Promise<JsonRpcTransactionReceipt>
 
 export default function provideGetTransactionReceipt(
   ethersProvider: providers.JsonRpcProvider,
-  ethersAgentRegistryProvider: providers.JsonRpcProvider,
   cache: Cache
 ) {
   assertExists(ethersProvider, 'ethersProvider')
-  assertExists(ethersAgentRegistryProvider, 'ethersAgentRegistryProvider')
   assertExists(cache, 'cache')
 
-  return async function getTransactionReceipt(txHash: string, onAgentRegistry: boolean = false) {
+  return async function getTransactionReceipt(txHash: string) {
     // check cache first
     const cachedReceipt = cache.getKey(txHash.toLowerCase())
     if (cachedReceipt) return cachedReceipt
 
     // fetch the receipt
-    const receipt =  onAgentRegistry ? 
-      await ethersAgentRegistryProvider.send('eth_getTransactionReceipt',[txHash]) :
-      await ethersProvider.send('eth_getTransactionReceipt',[txHash])
+    const receipt =  await ethersProvider.send('eth_getTransactionReceipt',[txHash])
 
     cache.setKey(txHash.toLowerCase(), receipt)
     return receipt

--- a/cli/utils/get.transaction.receipt.ts
+++ b/cli/utils/get.transaction.receipt.ts
@@ -13,29 +13,32 @@ export type JsonRpcTransactionReceipt = Omit<Receipt, 'status' | 'blockNumber' |
   status: string,
   blockNumber: string,
   transactionIndex: string,
+  from: string,
   logs: JsonRpcLog[]
 }
 
 // returns a transaction receipt as provided by the "eth_getTransactionReceipt" json-rpc method
-export type GetTransactionReceipt = (txHash: string) => Promise<JsonRpcTransactionReceipt>
+export type GetTransactionReceipt = (txHash: string,  onAgentRegistry?: boolean) => Promise<JsonRpcTransactionReceipt>
 
 export default function provideGetTransactionReceipt(
   ethersProvider: providers.JsonRpcProvider,
+  ethersAgentRegistryProvider: providers.JsonRpcProvider,
   cache: Cache
 ) {
   assertExists(ethersProvider, 'ethersProvider')
+  assertExists(ethersAgentRegistryProvider, 'ethersAgentRegistryProvider')
   assertExists(cache, 'cache')
 
-  return async function getTransactionReceipt(txHash: string) {
+  return async function getTransactionReceipt(txHash: string, onAgentRegistry: boolean = false) {
     // check cache first
     const cachedReceipt = cache.getKey(txHash.toLowerCase())
     if (cachedReceipt) return cachedReceipt
 
     // fetch the receipt
-    const receipt = await ethersProvider.send(
-      'eth_getTransactionReceipt',
-      [txHash]
-    )
+    const receipt =  onAgentRegistry ? 
+      await ethersAgentRegistryProvider.send('eth_getTransactionReceipt',[txHash]) :
+      await ethersProvider.send('eth_getTransactionReceipt',[txHash])
+
     cache.setKey(txHash.toLowerCase(), receipt)
     return receipt
   }

--- a/cli/utils/ipfs/get.from.ipfs.spec.ts
+++ b/cli/utils/ipfs/get.from.ipfs.spec.ts
@@ -1,4 +1,5 @@
-import provideGetFromIpfs, { formatIpfsData, GetFromIpfs, IpfsMetadata } from "./get.from.ipfs";
+import { formatIpfsData } from "../../commands/info";
+import provideGetFromIpfs, { GetFromIpfs, IpfsData, IpfsManifestData } from "./get.from.ipfs";
 
 const mockIpfsData = {
     "manifest":{
@@ -18,8 +19,7 @@ const mockIpfsData = {
           1
        ],
        "publishedFrom":"Forta Explorer 0.0.2"
-    } as IpfsMetadata,
-    "signature":"0x53dec496268d1a963984485cc92481f838b9f2fffd72b9afc617e58c5ea79b31291b53ee33d4c383ec7e6a89fdc2b58bb2d383213c5e406c0d20666d0ce536bf1c"
+    } as IpfsManifestData
 }
 
 
@@ -50,7 +50,7 @@ describe("getFromIpfs", () => {
             version: dataManifest.version,
             owner: dataManifest.from,
             image: dataManifest.imageReference,
-            published_from: dataManifest.publishedFrom,
+            publishedFrom: dataManifest.publishedFrom,
             timestamp: dataManifest.timestamp,
             documentation: ` https://ipfs.io/ipfs/${dataManifest.documentation}`
         }
@@ -61,7 +61,7 @@ describe("getFromIpfs", () => {
     it("returns ipfs manifest", async () => {
         mockIpfsClient.get.mockReturnValueOnce({ data: mockIpfsData})
         const data = await getFromIpfs("12345")
-        expect(data).toEqual(mockIpfsData.manifest)
+        expect(data).toEqual(mockIpfsData)
     })
 
     it("throws an error if no data found for given ipfs hash", async () => {

--- a/cli/utils/ipfs/get.from.ipfs.spec.ts
+++ b/cli/utils/ipfs/get.from.ipfs.spec.ts
@@ -1,0 +1,76 @@
+import provideGetFromIpfs, { formatIpfsData, GetFromIpfs, IpfsMetadata } from "./get.from.ipfs";
+
+const mockIpfsData = {
+    "manifest":{
+       "from":"0x123456",
+       "name":"Compound Liquidatable Positions Monitor",
+       "agentId":"Compound Liquidatable Positions Monitor",
+       "agentIdHash":"0x3c61101f1d349661298a58ba59a58fbce5a3626c5c7af10b091796969e0d6c59",
+       "version":"0.0.1",
+       "timestamp":"Fri, 20 May 2022 15:54:56 GMT",
+       "imageReference":"bafybeib5kmox5r2wpre3tgkfgfr76tm4qascagmqvod2wcojxrqmgyxfp4@sha256:2fcfede6f821f4f14e745598fd71b2201471517acd345f7b8f0cd424d35b441a",
+       "documentation":"QmQXZvBdZ4eMtCefNXYMRwQ7UJbgW74EqrMv9wS9hoSXV7",
+       "repository":"https://github.com/arbitraryexecution/compound-monitoring/tree/main/liquidation-monitor",
+       "projects":[
+          "compound_v2"
+       ],
+       "chainIds":[
+          1
+       ],
+       "publishedFrom":"Forta Explorer 0.0.2"
+    } as IpfsMetadata,
+    "signature":"0x53dec496268d1a963984485cc92481f838b9f2fffd72b9afc617e58c5ea79b31291b53ee33d4c383ec7e6a89fdc2b58bb2d383213c5e406c0d20666d0ce536bf1c"
+}
+
+
+describe("getFromIpfs", () => {
+    let getFromIpfs: GetFromIpfs;
+    const mockIpfsClient = {
+        get: jest.fn()
+    } as any
+
+    const resetMocks = () => {
+        mockIpfsClient.get.mockReset()
+    }
+
+    beforeEach(() => resetMocks())
+
+    beforeAll(() => {
+        getFromIpfs = provideGetFromIpfs(mockIpfsClient)
+    })
+
+    it("correctly formats Ipfs data in enabled state", async () => {
+        const dataManifest = mockIpfsData.manifest
+        const formattedData = formatIpfsData(dataManifest, true);
+
+        const correctFormat = {
+            name: dataManifest.name,
+            agentId: dataManifest.agentIdHash,
+            status: "Enabled",
+            version: dataManifest.version,
+            owner: dataManifest.from,
+            image: dataManifest.imageReference,
+            published_from: dataManifest.publishedFrom,
+            timestamp: dataManifest.timestamp,
+            documentation: ` https://ipfs.io/ipfs/${dataManifest.documentation}`
+        }
+
+        expect(formattedData).toEqual(correctFormat)
+    })
+
+    it("returns ipfs manifest", async () => {
+        mockIpfsClient.get.mockReturnValueOnce({ data: mockIpfsData})
+        const data = await getFromIpfs("12345")
+        expect(data).toEqual(mockIpfsData.manifest)
+    })
+
+    it("throws an error if no data found for given ipfs hash", async () => {
+        const metaHash = "12345"
+        try {
+            mockIpfsClient.get.mockReturnValueOnce({})
+            await getFromIpfs(metaHash)
+        } catch(e) {
+            expect(e.message).toBe(`No data found for ipfs hash ${metaHash}`)
+        }
+    })
+})

--- a/cli/utils/ipfs/get.from.ipfs.ts
+++ b/cli/utils/ipfs/get.from.ipfs.ts
@@ -1,9 +1,13 @@
 import { AxiosInstance } from "axios";
 import { assertExists } from "..";
 
-export type GetFromIpfs = (metadataHash: string) => Promise<IpfsMetadata>
+export type GetFromIpfs = (metadataHash: string) => Promise<IpfsData>
 
-export interface IpfsMetadata {
+export interface IpfsData {
+    manifest: IpfsManifestData
+}
+
+export interface IpfsManifestData {
     name: string,
     from: string,
     agentId: string,
@@ -25,23 +29,9 @@ export default function provideGetFromIpfs(
         const { data } = await ipfsHttpClient.get(`/ipfs/${metadataHash}`);
 
         if(data && data.manifest) {
-            return data.manifest;
+            return data;
         }
 
         throw Error(`No data found for ipfs hash ${metadataHash}`)
-    }
-}
-
-export const formatIpfsData = (data: IpfsMetadata, isBotEnabled: boolean) => {
-    return {
-        name: data.name,
-        agentId: data.agentIdHash,
-        status: isBotEnabled ? "Enabled" : "Disabled",
-        version: data.version,
-        owner: data.from,
-        image: data.imageReference,
-        published_from: data.publishedFrom,
-        timestamp: data.timestamp,
-        documentation: ` https://ipfs.io/ipfs/${data.documentation}`
     }
 }

--- a/cli/utils/ipfs/get.from.ipfs.ts
+++ b/cli/utils/ipfs/get.from.ipfs.ts
@@ -1,0 +1,26 @@
+import { AxiosInstance } from "axios";
+import { assertExists } from "..";
+
+export type GetFromIpfs = (metadataHash: string) => Promise<IpfsMetadata>
+
+export interface IpfsMetadata {
+    name: string,
+    from: string,
+    agentId: string,
+    version: string,
+    imageReference: string,
+    agentIdHash: string,
+    timestamp: string,
+    repository: string,
+}
+
+export default function provideGetFromIpfs(
+    ipfsHttpClient: AxiosInstance
+): GetFromIpfs {
+    assertExists(ipfsHttpClient, 'ipfsHttpClient')
+
+    return async function getIpfsByHash(metadataHash: string) {
+        const { data } = await ipfsHttpClient.get(`/ipfs/${metadataHash}`);
+        return data.manifest;
+    }
+}

--- a/cli/utils/ipfs/get.from.ipfs.ts
+++ b/cli/utils/ipfs/get.from.ipfs.ts
@@ -23,15 +23,20 @@ export default function provideGetFromIpfs(
 
     return async function getIpfsByHash(metadataHash: string) {
         const { data } = await ipfsHttpClient.get(`/ipfs/${metadataHash}`);
-        return data.manifest;
+
+        if(data && data.manifest) {
+            return data.manifest;
+        }
+
+        throw Error(`No data found for ipfs hash ${metadataHash}`)
     }
 }
 
-export const formatIpfsData = (data: IpfsMetadata, botStatus: boolean) => {
+export const formatIpfsData = (data: IpfsMetadata, isBotEnabled: boolean) => {
     return {
         name: data.name,
         agentId: data.agentIdHash,
-        status: botStatus ? "Enabled" : "Disabled",
+        status: isBotEnabled ? "Enabled" : "Disabled",
         version: data.version,
         owner: data.from,
         image: data.imageReference,

--- a/cli/utils/ipfs/get.from.ipfs.ts
+++ b/cli/utils/ipfs/get.from.ipfs.ts
@@ -12,6 +12,8 @@ export interface IpfsMetadata {
     agentIdHash: string,
     timestamp: string,
     repository: string,
+    publishedFrom: string,
+    documentation: string
 }
 
 export default function provideGetFromIpfs(
@@ -22,5 +24,19 @@ export default function provideGetFromIpfs(
     return async function getIpfsByHash(metadataHash: string) {
         const { data } = await ipfsHttpClient.get(`/ipfs/${metadataHash}`);
         return data.manifest;
+    }
+}
+
+export const formatIpfsData = (data: IpfsMetadata, botStatus: boolean) => {
+    return {
+        name: data.name,
+        agentId: data.agentIdHash,
+        status: botStatus ? "Enabled" : "Disabled",
+        version: data.version,
+        owner: data.from,
+        image: data.imageReference,
+        published_from: data.publishedFrom,
+        timestamp: data.timestamp,
+        documentation: ` https://ipfs.io/ipfs/${data.documentation}`
     }
 }

--- a/cli/utils/polyscan/get.logs.from.polyscan.ts
+++ b/cli/utils/polyscan/get.logs.from.polyscan.ts
@@ -1,0 +1,62 @@
+import { AxiosStatic } from "axios";
+import { assertExists } from "..";
+import { StateChangeContractEvent } from "../../contracts/agent.registry";
+
+
+export interface EventFilter{
+    type: StateChangeContractEvent
+    topic_0: string
+}
+
+export interface PolyscanLog{
+    topics: string[],
+    timeStamp: number,
+    transactionHash: string
+}
+
+export type GetLogsFromPolyscan = (address: string, eventFilter: EventFilter, agentId: string) => Promise<any>
+
+
+export default function provideGetLogsFromPolyscan(
+    axios: AxiosStatic,
+    polyscanApiUrl: string,
+): GetLogsFromPolyscan {
+
+    assertExists(axios,'axios')
+
+    return async function getLogsFromPolyscan(address: string, eventFilter: EventFilter, agentId: string) {
+
+        const agentIdFilterParams = eventFilter.type !== "Transfer" ? 
+            {
+                topic1: agentId,
+                topic0_1_opr: "and"
+            } :
+            {
+                topic3: agentId,
+                topic0_3_opr: "and"
+            }
+
+
+        const response = await axios.get(polyscanApiUrl, {
+            headers: {
+              "accept": "application/json",
+            },
+            params: {
+              apikey: "UYNC8TFCFJ9HJVMMY9Z6X4DVW2W5K1NII2",
+              module: "logs",
+              action: "getLogs",
+              address,
+              topic0: eventFilter.topic_0,
+              ...agentIdFilterParams
+            }
+          });
+
+          const {data} = response
+
+          if(typeof data.result === 'string') {
+              throw Error(`Failed to call polyscan api: ${data.result}`)
+          }
+          const hasData = data && data.result && data.result.length > 0;
+          return hasData ? data.result : []
+    }
+}

--- a/cli/utils/polyscan/get.logs.from.polyscan.ts
+++ b/cli/utils/polyscan/get.logs.from.polyscan.ts
@@ -1,11 +1,12 @@
 import { AxiosStatic } from "axios";
 import { assertExists } from "..";
 import { StateChangeContractEvent } from "../../contracts/agent.registry";
+import retry from "async-retry";
 
 
 export interface EventFilter{
     type: StateChangeContractEvent
-    topic_0: string
+    topicHash: string
 }
 
 export interface PolyscanLog{
@@ -35,28 +36,41 @@ export default function provideGetLogsFromPolyscan(
                 topic3: agentId,
                 topic0_3_opr: "and"
             }
+        let logData: PolyscanLog[] = []
 
+        const apiKey = getApiKey()
 
-        const response = await axios.get(polyscanApiUrl, {
-            headers: {
-              "accept": "application/json",
-            },
-            params: {
-              apikey: "UYNC8TFCFJ9HJVMMY9Z6X4DVW2W5K1NII2",
-              module: "logs",
-              action: "getLogs",
-              address,
-              topic0: eventFilter.topic_0,
-              ...agentIdFilterParams
-            }
-          });
+        await retry(async ()=> {
+            const response = await axios.get(polyscanApiUrl, {
+                headers: {
+                  "accept": "application/json",
+                },
+                params: {
+                  apikey: apiKey,
+                  module: "logs",
+                  action: "getLogs",
+                  address,
+                  topic0: eventFilter.topicHash,
+                  ...agentIdFilterParams
+                }
+            });
+    
+              const {data} = response;
+    
+              const hasData = data && data.result && data.result.length > 0;
+    
+              if(typeof data.result === 'string') {
+                  throw Error(`Failed to call polyscan api: ${data.result}`)
+              }
+    
+              logData = hasData ? data.result : []
+        }, { retries: 3})
 
-          const {data} = response
-
-          if(typeof data.result === 'string') {
-              throw Error(`Failed to call polyscan api: ${data.result}`)
-          }
-          const hasData = data && data.result && data.result.length > 0;
-          return hasData ? data.result : []
+        return logData
     }
+}
+
+// Randomly selects an api key to use for polyscan. Each api key allows us 5 req/sec
+const getApiKey = (): string => {
+    return (Math.floor(Math.random() * 10) % 2) === 0 ? "UYNC8TFCFJ9HJVMMY9Z6X4DVW2W5K1NII2" : "GVEAVC3WQYH9JH26MHD7THVQRQ5U5SP9R8"
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "scripts": {
     "build": "npm run js:build",
+    "build:local": "npm run js:build && yarn link && yarn link forta-agent",
     "js:build": "tsc --p ./tsconfig.build.json && cp -r ./starter-project ./dist && cp ./cli/commands/init/forta.config.json ./dist/cli/commands/init/forta.config.json && cp ./cli/commands/run/server/agent.proto ./dist/cli/commands/run/server/agent.proto",
     "js:publish": "npm run js:build && npm publish",
     "js:publish:local": "npm link",
@@ -29,7 +30,9 @@
   "dependencies": {
     "@grpc/grpc-js": "^1.3.6",
     "@grpc/proto-loader": "^0.6.4",
+    "@types/async-retry": "^1.4.4",
     "@types/uuid": "^8.3.4",
+    "async-retry": "^1.3.3",
     "awilix": "^4.3.4",
     "axios": "^0.21.1",
     "ethers": "^5.5.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   "dependencies": {
     "@grpc/grpc-js": "^1.3.6",
     "@grpc/proto-loader": "^0.6.4",
-    "@types/async-retry": "^1.4.4",
     "@types/uuid": "^8.3.4",
     "async-retry": "^1.3.3",
     "awilix": "^4.3.4",
@@ -53,6 +52,7 @@
     "@types/jest": "^26.0.22",
     "@types/lodash": "^4.14.170",
     "@types/n-readlines": "^1.0.2",
+    "@types/async-retry": "^1.4.4",
     "@types/node": "^15.12.2",
     "@types/prompts": "^2.0.14",
     "@types/shelljs": "^0.8.8",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   },
   "scripts": {
     "build": "npm run js:build",
-    "build:local": "npm run js:build && yarn link && yarn link forta-agent",
     "js:build": "tsc --p ./tsconfig.build.json && cp -r ./starter-project ./dist && cp ./cli/commands/init/forta.config.json ./dist/cli/commands/init/forta.config.json && cp ./cli/commands/run/server/agent.proto ./dist/cli/commands/run/server/agent.proto",
     "js:publish": "npm run js:build && npm publish",
     "js:publish:local": "npm link",


### PR DESCRIPTION
Added new cli command `info` which first fetches/displays metadata from IPFS, then fetches the last 1000 bot events via polyscans api.

Optional parameter for cli:
- `agentId`: Id of agent to fetch info for. If no agentId is specified  we use the agentId in `forta.config.json`.

IPFS metadata format:

- name
- agentId
- status
- version
- owner (Address that deployed bot)
- image (docker image tag)
- published_from
- timestamp
- documentation


Events that are printed:

- Bot Created
- Bot Enabled/Disabled
- Bot Updated






Example bot



https://user-images.githubusercontent.com/40375385/174321227-153ed32d-64b3-438b-9b68-a0947f4d05bb.mov





