### PR TITLE
 Typescript SDK: Adding method to fetch bot alerts using fortas graphql api

### DIFF
--- a/sdk/alert.ts
+++ b/sdk/alert.ts
@@ -3,8 +3,8 @@ export interface Alert {
     alertId: string,
     contracts: {
         address: string,
-        name: string,
-        projectId: string
+        name?: string,
+        projectId?: string
     }[],
     createdAt: string,
     description: string,
@@ -14,6 +14,40 @@ export interface Alert {
     scanNodeCount: number,
     severity: string,
     source: {
-        transactionHash: string
+        transactionHash: string,
+        block?: {
+            timestamp: string,
+            chainId: number,
+            hash: string,
+            number: number // block number
+        }
+        bot: {
+            id: string,
+            reference?: string,
+            image?: string,
+        }
     }
+    metadata?: any,
+    projects?: {
+        id: string,
+        name?: string,
+        contacts?: {
+            securityEmailAddress: string,
+            generalEmailAddress: string
+        },
+        website?: string,
+        token?: {
+            symbol: string,
+            name: string,
+            decimals: number,
+            chainId: number,
+            address: string
+        },
+        social?:{
+            twitter: string,
+            github: string,
+            everest: string,
+            coingecko: string
+        }
+    } []
 }

--- a/sdk/alert.ts
+++ b/sdk/alert.ts
@@ -1,0 +1,19 @@
+export interface Alert {
+    addresses: string[],
+    alertId: string,
+    contracts: {
+        address: string,
+        name: string,
+        projectId: string
+    }[],
+    createdAt: string,
+    description: string,
+    findingType: string,
+    name: string,
+    protocol: string,
+    scanNodeCount: number,
+    severity: string,
+    source: {
+        transactionHash: string
+    }
+}

--- a/sdk/graphql/forta.ts
+++ b/sdk/graphql/forta.ts
@@ -1,0 +1,127 @@
+import { Alert } from '../alert'
+
+export const FORTA_GRAPHQL_URL = "https://api.forta.network/graphql";
+
+export interface AlertQueryOptions {
+    botIds: string[], // filter results by bot ids
+    addresses?: string[], // filter results based on addresses involved in alerts
+    alertId?: string,
+    chainId?: number,
+    createdSince?: Date,
+    first?: number, // indicates max number of results,
+    projectId?: string, 
+    scanNodeConfirmations?: { // filter results by number of scan nodes confirming the alert 
+        gte: number,
+        lte: number
+    },
+    severities?: string[], // filter results by severity levels,
+    transactionHash?: string,
+    blockSortDirection?: "desc" | "asc", // set sorting order by block number
+    blockDateRange?: {
+        startDate: Date,
+        endDate: Date
+    }
+    blockNumberRange?: {
+        startBlockNumber: number,
+        endBlockNumber: number
+    }
+}
+
+export interface AlertsResponse {
+    alerts: Alert[],
+    pageInfo: {
+        hasNextPage: boolean
+    }
+}
+
+export interface RawGraphqlResponse {
+    data: {
+        data: any,
+        errors: any
+    }
+}
+
+export const getQueryFromAlertOptions = (options: AlertQueryOptions) => {
+    return {
+        "operationName": "fetchAlerts",
+        "query" : `
+            query fetchAlerts(
+                $bots: [String]!, 
+                $addresses: [String], 
+                $alertId: String, 
+                $chainId: NonNegativeInt,
+                $first: NonNegativeInt,
+                $projectId: String,
+                $scanNodeConfirmations: scanNodeFilters,
+                $severities: [String],
+                $transactionHash: String,
+                $blockSortDirection: Sort,
+                $createdSince: NonNegativeInt,
+                $blockDateRange: DateRange,
+                $blockNumberRange: BlockRange
+                ) {
+                    alerts(input:{
+                        bots: $bots,
+                        addresses: $addresses,
+                        alertId: $alertId,
+                        chainId: $chainId,
+                        projectId: $projectId,
+                        scanNodeConfirmations: $scanNodeConfirmations,
+                        severities: $severities,
+                        transactionHash: $transactionHash,
+                        blockSortDirection: $blockSortDirection,
+                        first: $first,
+                        createdSince: $createdSince,
+                        blockDateRange: $blockDateRange,
+                        blockNumberRange: $blockNumberRange
+                    }) {
+                        alerts {
+                            alertId
+                            addresses
+                            contracts {
+                                address
+                                name
+                                projectId
+                            }
+                            createdAt
+                            description
+                            findingType
+                            name
+                            projects {
+                                id
+                            }
+                            protocol
+                            scanNodeCount
+                            severity
+                            source {
+                                transactionHash
+                                bot {
+                                    id
+                                }
+                            }
+                        }
+                        pageInfo {
+                            hasNextPage
+                        }
+                    }
+            }
+        `,
+        "variables": {
+            bots: options.botIds,
+            addresses: options.addresses,
+            alertId: options.alertId,
+            chainId: options.chainId,
+            first: options.first,
+            projectId: options.projectId,
+            scanNodeConfirmations: options.scanNodeConfirmations,
+            severities: options.severities,
+            transactionHash: options.transactionHash,
+            blockSortDirection: options.blockSortDirection,
+            createdSince: options.createdSince?.getDate(),
+            blockDateRange: options.blockDateRange ? 
+                { startDate: options.blockDateRange.startDate.toISOString().split('T')[0], endDate: options.blockDateRange.endDate.toISOString().split('T')[0]} :
+                undefined,
+            blockNumberRange: options.blockNumberRange
+        } 
+    }
+}

--- a/sdk/index.ts
+++ b/sdk/index.ts
@@ -16,7 +16,7 @@ import {
   setPrivateFindings,
   isPrivateFindings,
   getTransactionReceipt,
-  getFortaAlerts
+  getAlerts
 } from "./utils"
 import awilixConfigureContainer from '../cli/di.container';
 
@@ -100,5 +100,5 @@ export {
   isPrivateFindings,
   configureContainer,
   getTransactionReceipt,
-  getFortaAlerts
+  getAlerts
  }

--- a/sdk/index.ts
+++ b/sdk/index.ts
@@ -15,7 +15,8 @@ import {
   keccak256,
   setPrivateFindings,
   isPrivateFindings,
-  getTransactionReceipt
+  getTransactionReceipt,
+  getFortaAlerts
 } from "./utils"
 import awilixConfigureContainer from '../cli/di.container';
 
@@ -98,5 +99,6 @@ export {
   setPrivateFindings,
   isPrivateFindings,
   configureContainer,
-  getTransactionReceipt
+  getTransactionReceipt,
+  getFortaAlerts
  }

--- a/sdk/utils.ts
+++ b/sdk/utils.ts
@@ -10,6 +10,8 @@ import { Log, Receipt } from './receipt'
 import { TxEventBlock } from './transaction.event'
 import { Block } from './block'
 import { ethers } from '.'
+import { AlertQueryOptions, AlertsResponse, FORTA_GRAPHQL_URL, getQueryFromAlertOptions, RawGraphqlResponse } from './graphql/forta'
+import axios from 'axios'
 
 export const getEthersProvider = () => {
   return new ethers.providers.JsonRpcProvider(getJsonRpcUrl())
@@ -142,4 +144,12 @@ export const setPrivateFindings = (isPrivate: boolean) => {
 
 export const isPrivateFindings = () => {
   return IS_PRIVATE_FINDINGS
+}
+
+export const getFortaAlerts = async (query: AlertQueryOptions): Promise<AlertsResponse> => {
+  const response: RawGraphqlResponse = await axios.post(FORTA_GRAPHQL_URL, getQueryFromAlertOptions(query), {headers: {"content-type": "application/json"}});
+
+  if(response.data && response.data.errors) throw Error(response.data.errors)
+
+  return response.data.data
 }

--- a/sdk/utils.ts
+++ b/sdk/utils.ts
@@ -10,7 +10,7 @@ import { Log, Receipt } from './receipt'
 import { TxEventBlock } from './transaction.event'
 import { Block } from './block'
 import { ethers } from '.'
-import { AlertQueryOptions, AlertsResponse, FORTA_GRAPHQL_URL, getQueryFromAlertOptions, RawGraphqlResponse } from './graphql/forta'
+import { AlertQueryOptions, AlertsResponse, FORTA_GRAPHQL_URL, getQueryFromAlertOptions, RawGraphqlAlertResponse } from './graphql/forta'
 import axios from 'axios'
 
 export const getEthersProvider = () => {
@@ -146,10 +146,10 @@ export const isPrivateFindings = () => {
   return IS_PRIVATE_FINDINGS
 }
 
-export const getFortaAlerts = async (query: AlertQueryOptions): Promise<AlertsResponse> => {
-  const response: RawGraphqlResponse = await axios.post(FORTA_GRAPHQL_URL, getQueryFromAlertOptions(query), {headers: {"content-type": "application/json"}});
+export const getAlerts = async (query: AlertQueryOptions): Promise<AlertsResponse> => {
+  const response: RawGraphqlAlertResponse = await axios.post(FORTA_GRAPHQL_URL, getQueryFromAlertOptions(query), {headers: {"content-type": "application/json"}});
 
   if(response.data && response.data.errors) throw Error(response.data.errors)
 
-  return response.data.data
+  return response.data.data.alerts
 }


### PR DESCRIPTION
The goal of this PR is integrating forta's graphql api into the sdk.

- [x] Add new util method `getFortaAlerts`
- [x] Support pagination through alerts
- [x] Test with a simple script that uses calls the new util method for real bots and prints results to screen
- [x] Validate all query params operate correctly


Example output from test script that calls `getFortaAlerts` for a bot after the date `2022-06-30`.
<img width="953" alt="Screen Shot 2022-06-30 at 8 23 29 AM" src="https://user-images.githubusercontent.com/40375385/176676338-d8138657-7d3f-4b08-9228-b5939a5ce4c1.png">

