### PR TITLE
Limit size of findings returned from handleBlock and handleTransaction bot methods

### DIFF
--- a/cli/commands/run/server/agent.controller.js
+++ b/cli/commands/run/server/agent.controller.js
@@ -24,7 +24,12 @@ module.exports = class AgentController {
     if (this.handleBlock) {
       try {
         const blockEvent = this.createBlockEventFromGrpcRequest(call.request);
-        findings.push(...(await this.handleBlock(blockEvent)));
+
+        const returnedFindings = await this.handleBlock(blockEvent);
+        
+        if(returnedFindings.length > 10) throw Error("Found more than 10 findings when executing block handler.")
+
+        findings.push(...returnedFindings);
       } catch (e) {
         console.log(
           `${new Date().toISOString()}    evaluateBlock ${
@@ -55,7 +60,12 @@ module.exports = class AgentController {
         const txEvent = this.createTransactionEventFromGrpcRequest(
           call.request
         );
-        findings.push(...(await this.handleTransaction(txEvent)));
+
+        const returnedFindings = await this.handleTransaction(txEvent);
+
+        if(returnedFindings.length > 10) throw Error("Found more than 10 findings when executing transaction handler.")
+
+        findings.push(...returnedFindings);
       } catch (e) {
         console.log(
           `${new Date().toISOString()}    evaluateTx ${

--- a/cli/commands/run/server/agent.controller.js
+++ b/cli/commands/run/server/agent.controller.js
@@ -3,7 +3,7 @@ const {
   TransactionEvent,
   isPrivateFindings,
 } = require("../../../../sdk");
-const { assertExists, formatAddress } = require("../../../utils");
+const { assertExists, formatAddress, assertFindings } = require("../../../utils");
 
 module.exports = class AgentController {
   constructor(getAgentHandlers) {
@@ -27,7 +27,7 @@ module.exports = class AgentController {
 
         const returnedFindings = await this.handleBlock(blockEvent);
         
-        if(returnedFindings.length > 10) throw Error("Found more than 10 findings when executing block handler.")
+        assertFindings(returnedFindings)
 
         findings.push(...returnedFindings);
       } catch (e) {
@@ -63,7 +63,7 @@ module.exports = class AgentController {
 
         const returnedFindings = await this.handleTransaction(txEvent);
 
-        if(returnedFindings.length > 10) throw Error("Found more than 10 findings when executing transaction handler.")
+        assertFindings(returnedFindings)
 
         findings.push(...returnedFindings);
       } catch (e) {

--- a/cli/commands/run/server/agent.controller.spec.ts
+++ b/cli/commands/run/server/agent.controller.spec.ts
@@ -273,7 +273,7 @@ describe("AgentController", () => {
     })
 
     it("throws an error if more than 50kB of findings fetched when handling a block", async () => {
-      const findings = (new Array(1)).fill({ some: 'f'.repeat(51000) })
+      const findings = (new Array(1)).fill({ some: 'f'.repeat(1024 * 50) })
       mockHandleBlock.mockReturnValue(findings)
       mockGetAgentHandlers.mockReturnValue({ handleBlock: mockHandleBlock })
       agentController = new AgentController(mockGetAgentHandlers)
@@ -447,7 +447,7 @@ describe("AgentController", () => {
     })
 
     it("throws an error if more than 50kB of findings fetched when handling a transaction", async () => {
-      const findings = (new Array(1)).fill({ some: 'f'.repeat(51000) })
+      const findings = (new Array(1)).fill({ some: 'f'.repeat(1024 * 50) })
       mockHandleTransaction.mockReturnValue(findings)
       mockGetAgentHandlers.mockReturnValue({ handleTransaction: mockHandleTransaction })
       agentController = new AgentController(mockGetAgentHandlers)

--- a/cli/commands/run/server/agent.controller.spec.ts
+++ b/cli/commands/run/server/agent.controller.spec.ts
@@ -11,7 +11,6 @@ describe("AgentController", () => {
   const mockCallback = jest.fn()
   const mockFinding = { some: 'finding' }
   const systemTime = new Date()
-  const consoleSpy = jest.spyOn(console, 'log');
 
   const generateBlockRequest = () => ({
     request: {
@@ -125,7 +124,6 @@ describe("AgentController", () => {
     mockGetAgentHandlers.mockReset()
     mockHandleBlock.mockReset()
     mockHandleTransaction.mockReset()
-    consoleSpy.mockReset()
   }
 
   beforeEach(() => resetMocks())
@@ -272,7 +270,6 @@ describe("AgentController", () => {
           private: false
         })
 
-        expect(consoleSpy).toBeCalledTimes(2)
     })
   })
 
@@ -420,7 +417,6 @@ describe("AgentController", () => {
         await agentController.initializeAgentHandlers()
         await agentController.EvaluateTx(mockTxRequest, mockCallback)
 
-        expect(consoleSpy).toBeCalledTimes(2)
         expect(mockCallback).toHaveBeenCalledWith(null, {
           status: "ERROR",
           findings: [],
@@ -440,7 +436,6 @@ describe("AgentController", () => {
       await agentController.initializeAgentHandlers()
       await agentController.EvaluateTx(mockTxRequest, mockCallback)
 
-      expect(consoleSpy).toBeCalledTimes(2)
       expect(mockCallback).toHaveBeenCalledWith(null, {
         status: "ERROR",
         findings: [],

--- a/cli/commands/run/server/agent.controller.spec.ts
+++ b/cli/commands/run/server/agent.controller.spec.ts
@@ -271,6 +271,25 @@ describe("AgentController", () => {
         })
 
     })
+
+    it("throws an error if more than 50kB of findings fetched when handling a block", async () => {
+      const findings = (new Array(1)).fill({ some: 'f'.repeat(51000) })
+      mockHandleBlock.mockReturnValue(findings)
+      mockGetAgentHandlers.mockReturnValue({ handleBlock: mockHandleBlock })
+      agentController = new AgentController(mockGetAgentHandlers)
+
+      await agentController.initializeAgentHandlers()
+      await agentController.EvaluateBlock(mockBlockRequest, mockCallback)
+
+      expect(mockCallback).toHaveBeenCalledWith(null, {
+        status: "ERROR",
+        findings: [],
+        metadata: {
+          timestamp: systemTime.toISOString(),
+        },
+        private: false
+      })
+    })
   })
 
   describe("EvaluateTx", () => {
@@ -444,6 +463,6 @@ describe("AgentController", () => {
         },
         private: false
       })
-  })
+    })
   })
 })

--- a/cli/commands/run/server/agent.controller.spec.ts
+++ b/cli/commands/run/server/agent.controller.spec.ts
@@ -430,5 +430,25 @@ describe("AgentController", () => {
           private: false
         })
     })
+
+    it("throws an error if more than 50kB of findings fetched when handling a transaction", async () => {
+      const findings = (new Array(1)).fill({ some: 'f'.repeat(51000) })
+      mockHandleTransaction.mockReturnValue(findings)
+      mockGetAgentHandlers.mockReturnValue({ handleTransaction: mockHandleTransaction })
+      agentController = new AgentController(mockGetAgentHandlers)
+
+      await agentController.initializeAgentHandlers()
+      await agentController.EvaluateTx(mockTxRequest, mockCallback)
+
+      expect(consoleSpy).toBeCalledTimes(2)
+      expect(mockCallback).toHaveBeenCalledWith(null, {
+        status: "ERROR",
+        findings: [],
+        metadata: {
+          timestamp: systemTime.toISOString(),
+        },
+        private: false
+      })
+  })
   })
 })

--- a/cli/utils/index.ts
+++ b/cli/utils/index.ts
@@ -6,7 +6,7 @@ import { Keccak } from 'sha3'
 import { ShellString } from 'shelljs'
 import { getContractAddress } from '@ethersproject/address'
 
-import { BlockEvent, EventType, Log, TransactionEvent } from "../../sdk"
+import { BlockEvent, EventType, Finding, Log, TransactionEvent } from "../../sdk"
 import { Trace } from '../../sdk/trace'
 import { JsonRpcBlock, JsonRpcTransaction } from './get.block.with.transactions'
 import { JsonRpcLog } from './get.transaction.receipt'
@@ -41,6 +41,13 @@ export const assertShellResult = (result: ShellString, errMsg: string) => {
   if (result.code !== 0) {
     throw new Error(`${errMsg}: ${result.stderr}`)
   }
+}
+
+export const assertFindings = (findings: Finding[]) => {
+  const serializedFindings = JSON.stringify(findings).length;
+
+  if(serializedFindings > 50000) throw Error(`Cannot return more than 50kB of findings per request (received ${findings.length})`)
+  if(findings.length > 10) throw Error(`Cannot return more than 10 findings per request (received ${findings.length})`)
 }
 
 export const isValidTimeRange = (earliestTimestamp: Date, latestTimestamp: Date): boolean => {

--- a/cli/utils/index.ts
+++ b/cli/utils/index.ts
@@ -44,9 +44,9 @@ export const assertShellResult = (result: ShellString, errMsg: string) => {
 }
 
 export const assertFindings = (findings: Finding[]) => {
-  const serializedFindings = JSON.stringify(findings).length;
+  const byteLength = Buffer.byteLength(JSON.stringify(findings));
 
-  if(serializedFindings > 50000) throw Error(`Cannot return more than 50kB of findings per request (received ${findings.length})`)
+  if(byteLength > 50000) throw Error(`Cannot return more than 50kB of findings per request (received ${byteLength} bytes)`)
   if(findings.length > 10) throw Error(`Cannot return more than 10 findings per request (received ${findings.length})`)
 }
 

--- a/cli/utils/index.ts
+++ b/cli/utils/index.ts
@@ -45,8 +45,9 @@ export const assertShellResult = (result: ShellString, errMsg: string) => {
 
 export const assertFindings = (findings: Finding[]) => {
   const byteLength = Buffer.byteLength(JSON.stringify(findings));
+  const kilobyte = 1024;
 
-  if(byteLength > 50000) throw Error(`Cannot return more than 50kB of findings per request (received ${byteLength} bytes)`)
+  if(byteLength > kilobyte * 50) throw Error(`Cannot return more than 50kB of findings per request (received ${byteLength} bytes)`)
   if(findings.length > 10) throw Error(`Cannot return more than 10 findings per request (received ${findings.length})`)
 }
 

--- a/cli/utils/run.handlers.on.block.spec.ts
+++ b/cli/utils/run.handlers.on.block.spec.ts
@@ -135,6 +135,7 @@ describe("runHandlersOnBlock", () => {
 
   it("throws an error if more than 50kB of findings found when handling a block", async () => {
     const findings = getFindingsArray(1, 51000)
+    const byteLength = Buffer.byteLength(JSON.stringify(findings));
     try {
 
       const mockHandleBlock = jest.fn().mockReturnValue(findings)
@@ -151,14 +152,14 @@ describe("runHandlersOnBlock", () => {
 
       fail()
     } catch(err) {
-      expect(err.message).toBe(`Cannot return more than 50kB of findings per request (received ${findings.length})`)
+      expect(err.message).toBe(`Cannot return more than 50kB of findings per request (received ${byteLength} bytes)`)
     }
   })
 
-  it("throws an error if more than 10 findings when handling a transaction", async () => {
+  it("throws an error if more than 50kB of findings found handling a transaction", async () => {
 
     const findings = getFindingsArray(1, 51000)
-
+    const byteLength = Buffer.byteLength(JSON.stringify(findings));
     try {
       const mockHandleBlock = jest.fn().mockReturnValue([])
       const mockHandleTransaction = jest.fn().mockReturnValue(findings)
@@ -181,7 +182,7 @@ describe("runHandlersOnBlock", () => {
 
       fail()
     }catch(err) {
-      expect(err.message).toBe(`Cannot return more than 50kB of findings per request (received ${findings.length})`)
+      expect(err.message).toBe(`Cannot return more than 50kB of findings per request (received ${byteLength} bytes)`)
     }
   })
 })

--- a/cli/utils/run.handlers.on.block.spec.ts
+++ b/cli/utils/run.handlers.on.block.spec.ts
@@ -134,7 +134,7 @@ describe("runHandlersOnBlock", () => {
   })
 
   it("throws an error if more than 50kB of findings found when handling a block", async () => {
-    const findings = getFindingsArray(1, 51000)
+    const findings = getFindingsArray(1, 1024 * 50)
     const byteLength = Buffer.byteLength(JSON.stringify(findings));
     try {
 
@@ -158,7 +158,7 @@ describe("runHandlersOnBlock", () => {
 
   it("throws an error if more than 50kB of findings found handling a transaction", async () => {
 
-    const findings = getFindingsArray(1, 51000)
+    const findings = getFindingsArray(1, 1024 * 50)
     const byteLength = Buffer.byteLength(JSON.stringify(findings));
     try {
       const mockHandleBlock = jest.fn().mockReturnValue([])

--- a/cli/utils/run.handlers.on.block.spec.ts
+++ b/cli/utils/run.handlers.on.block.spec.ts
@@ -1,3 +1,4 @@
+import { Finding, FindingSeverity, FindingType } from "../../sdk"
 import { provideRunHandlersOnBlock, RunHandlersOnBlock } from "./run.handlers.on.block"
 
 describe("runHandlersOnBlock", () => {
@@ -19,6 +20,16 @@ describe("runHandlersOnBlock", () => {
     )
   })
 
+  beforeEach(() => {
+    mockGetAgentHandlers.mockReset()
+    mockGetNetworkId.mockReset()
+    mockGetBlockWithTransactions.mockReset()
+    mockGetTraceData.mockReset()
+    mockGetLogsForBlock.mockReset()
+    mockCreateBlockEvent.mockReset()
+    mockCreateTransactionEvent.mockReset()
+  })
+
   it("throws an error if no handlers found", async () => {
     mockGetAgentHandlers.mockReturnValueOnce({ })
 
@@ -32,7 +43,6 @@ describe("runHandlersOnBlock", () => {
   })
 
   it("invokes block handlers with block event and transaction handlers with transaction event for each transaction in block", async () => {
-    mockGetAgentHandlers.mockReset()
     const mockHandleBlock = jest.fn().mockReturnValue([])
     const mockHandleTransaction = jest.fn().mockReturnValue([])
     mockGetAgentHandlers.mockReturnValueOnce({ handleBlock: mockHandleBlock, handleTransaction: mockHandleTransaction })
@@ -71,4 +81,66 @@ describe("runHandlersOnBlock", () => {
     expect(mockHandleTransaction).toHaveBeenCalledTimes(1)
     expect(mockHandleTransaction).toHaveBeenCalledWith(mockTxEvent)
   })
+
+  it("throws an error if more than 10 findings when handling a block", async () => {
+    try {
+      const findings = getFindingsArray(11)
+
+      const mockHandleBlock = jest.fn().mockReturnValue(findings)
+      mockGetAgentHandlers.mockReturnValueOnce({ handleBlock: mockHandleBlock })
+
+      const mockNetworkId = 1
+      mockGetNetworkId.mockReturnValueOnce(mockNetworkId)
+      const mockTransaction = { hash: mockTxHash }
+      const mockBlock = { hash: mockBlockHash, number: 7, transactions: [mockTransaction] }
+      mockGetBlockWithTransactions.mockReturnValueOnce(mockBlock)
+      mockCreateBlockEvent.mockReturnValueOnce({})
+
+      await runHandlersOnBlock(mockBlockHash)
+
+      fail()
+    } catch(err) {
+      expect(err.message).toBe('Found more than 10 findings when executing block handler.')
+    }
+  })
+
+  it("throws an error if more than 10 findings when handling a transaction", async () => {
+    try {
+      const findings = getFindingsArray(11)
+      const mockHandleBlock = jest.fn().mockReturnValue([])
+      const mockHandleTransaction = jest.fn().mockReturnValue(findings)
+      mockGetAgentHandlers.mockReturnValueOnce({ handleBlock: mockHandleBlock, handleTransaction: mockHandleTransaction })
+      const mockNetworkId = 1
+      mockGetNetworkId.mockReturnValueOnce(mockNetworkId)
+      const mockTransaction = { hash: mockTxHash }
+      const mockBlock = { hash: mockBlockHash, number: 7, transactions: [mockTransaction] }
+      mockGetBlockWithTransactions.mockReturnValueOnce(mockBlock)
+      const mockBlockEvent = {}
+      mockCreateBlockEvent.mockReturnValueOnce(mockBlockEvent)
+      const mockTrace = { transactionHash: mockTxHash, some: 'trace' }
+      mockGetTraceData.mockReturnValueOnce([mockTrace])
+      const mockLog = { transactionHash: mockTxHash, some: 'log' }
+      mockGetLogsForBlock.mockReturnValueOnce([mockLog])
+      const mockTxEvent = {}
+      mockCreateTransactionEvent.mockReturnValueOnce(mockTxEvent)
+
+      await runHandlersOnBlock(mockBlockHash)
+
+      fail()
+    }catch(err) {
+      expect(err.message).toBe('Found more than 10 findings when executing transaction handler.')
+    }
+  })
 })
+
+const getFindingsArray = (arraySize: number) => {
+  const finding: Finding = Finding.from( {
+    name: "test",
+    description: "test description",
+    alertId: "1234",
+    severity: FindingSeverity.Medium,
+    type: FindingType.Exploit
+  })
+
+  return (new Array(arraySize)).fill(finding)
+}

--- a/cli/utils/run.handlers.on.block.ts
+++ b/cli/utils/run.handlers.on.block.ts
@@ -42,6 +42,9 @@ export function provideRunHandlersOnBlock(
     if (handleBlock) {
       const blockEvent = createBlockEvent(block, networkId)
       const findings = await handleBlock(blockEvent)
+
+      if(findings.length > 10) throw Error("Found more than 10 findings when executing block handler.")
+      
       console.log(`${findings.length} findings for block ${block.hash} ${findings}`)
     }
 
@@ -76,6 +79,9 @@ export function provideRunHandlersOnBlock(
       const txHash = transaction.hash.toLowerCase()
       const txEvent = createTransactionEvent(transaction, block, networkId, traceMap[txHash], logMap[txHash])
       const findings = await handleTransaction(txEvent)
+
+      if(findings.length > 10) throw Error("Found more than 10 findings when executing transaction handler.")
+
       console.log(`${findings.length} findings for transaction ${transaction.hash} ${findings}`)
     }
   }

--- a/cli/utils/run.handlers.on.block.ts
+++ b/cli/utils/run.handlers.on.block.ts
@@ -1,7 +1,7 @@
 import { Trace } from "../../sdk";
 import { GetAgentHandlers } from "./get.agent.handlers";
 import { GetTraceData } from "./get.trace.data";
-import { assertExists, CreateBlockEvent, CreateTransactionEvent } from ".";
+import { assertExists, assertFindings, CreateBlockEvent, CreateTransactionEvent } from ".";
 import { GetNetworkId } from "./get.network.id";
 import { GetBlockWithTransactions } from "./get.block.with.transactions";
 import { JsonRpcLog } from "./get.transaction.receipt";
@@ -43,7 +43,7 @@ export function provideRunHandlersOnBlock(
       const blockEvent = createBlockEvent(block, networkId)
       const findings = await handleBlock(blockEvent)
 
-      if(findings.length > 10) throw Error("Found more than 10 findings when executing block handler.")
+      assertFindings(findings)
       
       console.log(`${findings.length} findings for block ${block.hash} ${findings}`)
     }
@@ -80,7 +80,7 @@ export function provideRunHandlersOnBlock(
       const txEvent = createTransactionEvent(transaction, block, networkId, traceMap[txHash], logMap[txHash])
       const findings = await handleTransaction(txEvent)
 
-      if(findings.length > 10) throw Error("Found more than 10 findings when executing transaction handler.")
+      assertFindings(findings)
 
       console.log(`${findings.length} findings for transaction ${transaction.hash} ${findings}`)
     }

--- a/cli/utils/run.handlers.on.transaction.spec.ts
+++ b/cli/utils/run.handlers.on.transaction.spec.ts
@@ -100,7 +100,7 @@ describe("runHandlersOnTransaction", () => {
   })
 
   it("throws an error if more than 50kB of findings found when executing transaction handler", async () => {
-    const findings = getFindingsArray(1, 51000)
+    const findings = getFindingsArray(1, 1024 * 50)
     const byteLength = Buffer.byteLength(JSON.stringify(findings));
     try {
       const mockHandleTransaction = jest.fn().mockReturnValue(findings)

--- a/cli/utils/run.handlers.on.transaction.spec.ts
+++ b/cli/utils/run.handlers.on.transaction.spec.ts
@@ -101,7 +101,7 @@ describe("runHandlersOnTransaction", () => {
 
   it("throws an error if more than 50kB of findings found when executing transaction handler", async () => {
     const findings = getFindingsArray(1, 51000)
-    
+    const byteLength = Buffer.byteLength(JSON.stringify(findings));
     try {
       const mockHandleTransaction = jest.fn().mockReturnValue(findings)
       mockGetAgentHandlers.mockReturnValueOnce({ handleTransaction: mockHandleTransaction })
@@ -122,7 +122,7 @@ describe("runHandlersOnTransaction", () => {
 
       fail()
     } catch(err) {
-      expect(err.message).toBe(`Cannot return more than 50kB of findings per request (received ${findings.length})`)
+      expect(err.message).toBe(`Cannot return more than 50kB of findings per request (received ${byteLength} bytes)`)
     }
   })
 

--- a/cli/utils/run.handlers.on.transaction.ts
+++ b/cli/utils/run.handlers.on.transaction.ts
@@ -1,4 +1,4 @@
-import { assertExists, CreateTransactionEvent } from ".";
+import { assertExists, assertFindings, CreateTransactionEvent } from ".";
 import { GetAgentHandlers } from "./get.agent.handlers";
 import { GetBlockWithTransactions } from "./get.block.with.transactions";
 import { GetNetworkId } from "./get.network.id";
@@ -40,7 +40,7 @@ export function provideRunHandlersOnTransaction(
     const txEvent = createTransactionEvent(transaction, block, networkId, traces, receipt.logs)
     const findings = await handleTransaction(txEvent)
     
-    if(findings.length > 10) throw Error("Found more than 10 findings when executing transaction handler.")
+    assertFindings(findings)
 
     console.log(`${findings.length} findings for transaction ${txHash} ${findings}`)
   }

--- a/cli/utils/run.handlers.on.transaction.ts
+++ b/cli/utils/run.handlers.on.transaction.ts
@@ -39,6 +39,9 @@ export function provideRunHandlersOnTransaction(
     const transaction = block.transactions.find(tx => tx.hash.toLowerCase() === txHash)!
     const txEvent = createTransactionEvent(transaction, block, networkId, traces, receipt.logs)
     const findings = await handleTransaction(txEvent)
+    
+    if(findings.length > 10) throw Error("Found more than 10 findings when executing transaction handler.")
+
     console.log(`${findings.length} findings for transaction ${txHash} ${findings}`)
   }
 }


### PR DESCRIPTION
Created new assert util function to validate findings from `handleBlock` or `handleTransaction` calls are below 50kB and there are no more than 10 findings.