### PR TITLE
Refactor jwt method names and and warning instead of throwing error

### DIFF
--- a/python-sdk/src/forta_agent/__init__.py
+++ b/python-sdk/src/forta_agent/__init__.py
@@ -7,7 +7,7 @@ from .receipt import Receipt, Log
 from .trace import Trace, TraceAction, TraceResult
 from .event_type import EventType
 from .network import Network
-from .utils import get_json_rpc_url, create_block_event, create_transaction_event, get_web3_provider, keccak256, get_transaction_receipt, get_alerts, fetch_Jwt_token, decode_Jwt_token
+from .utils import get_json_rpc_url, create_block_event, create_transaction_event, get_web3_provider, keccak256, get_transaction_receipt, get_alerts, fetch_jwt_token, decode_jwt_token
 from web3 import Web3
 
 web3Provider = Web3(Web3.HTTPProvider(get_json_rpc_url()))

--- a/python-sdk/src/forta_agent/utils.py
+++ b/python-sdk/src/forta_agent/utils.py
@@ -130,7 +130,7 @@ def keccak256(val):
     hash.update(bytes(val, encoding='utf-8'))
     return f'0x{hash.hexdigest()}'
 
-def fetch_Jwt_token(claims, expiresAt=None) -> str:
+def fetch_jwt_token(claims, expiresAt=None) -> str:
     host_name = 'forta-jwt-provider'
     port = 8515
     path = '/create'
@@ -158,11 +158,10 @@ def fetch_Jwt_token(claims, expiresAt=None) -> str:
     except requests.exceptions.RequestException as err:
         if("Name does not resolve" in str(err)):
             print("Could not resolve host 'forta-jwt-provider'. This url host can only be resolved inside of a running scan node")
-            raise err
         else:
             raise err
 
 
-def decode_Jwt_token(token):
+def decode_jwt_token(token):
     # Adding need 4 byte for pythons b64decode
     return base64.b64decode(token.split('.')[1] + '==').decode('utf-8')

--- a/sdk/utils.ts
+++ b/sdk/utils.ts
@@ -155,6 +155,8 @@ export const getAlerts = async (query: AlertQueryOptions): Promise<AlertsRespons
 }
 
 export const fetchJwtToken = async (claims: {}, expiresAt?: Date): Promise<{token: string} | null> => {
+  if (process.env.NODE_ENV !== 'production') return {token: "MOCK_JWT_TOKEN"}
+
   const hostname = 'forta-jwt-provider'
   const port = 8515
   const path = '/create'
@@ -182,7 +184,7 @@ export const fetchJwtToken = async (claims: {}, expiresAt?: Date): Promise<{toke
     return response.data
   } catch(err) {
     if((err.message as string).includes("ENOTFOUND forta-jwt-provider")) {
-      console.warn("Could not resolve host 'forta-jwt-provider'. This url host can only be resolved inside of a running scan node") 
+      throw Error("Could not resolve host 'forta-jwt-provider'. This url host can only be resolved inside of a running scan node") 
     }
     throw err
   }

--- a/sdk/utils.ts
+++ b/sdk/utils.ts
@@ -182,7 +182,7 @@ export const fetchJwtToken = async (claims: {}, expiresAt?: Date): Promise<{toke
     return response.data
   } catch(err) {
     if((err.message as string).includes("ENOTFOUND forta-jwt-provider")) {
-      throw Error("Could not resolve host 'forta-jwt-provider'. This url host can only be resolved inside of a running scan node") 
+      console.warn("Could not resolve host 'forta-jwt-provider'. This url host can only be resolved inside of a running scan node") 
     }
     throw err
   }


### PR DESCRIPTION
Updating python function names and logging a warning instead of throwing an error