### PR TITLE
Adding js/ts util method to verify JWT's generated by a scanner

### DIFF
--- a/python-sdk/src/forta_agent/__init__.py
+++ b/python-sdk/src/forta_agent/__init__.py
@@ -7,7 +7,7 @@ from .receipt import Receipt, Log
 from .trace import Trace, TraceAction, TraceResult
 from .event_type import EventType
 from .network import Network
-from .utils import get_json_rpc_url, create_block_event, create_transaction_event, get_web3_provider, keccak256, get_transaction_receipt, get_alerts, fetch_Jwt, decode_Jwt
+from .utils import get_json_rpc_url, create_block_event, create_transaction_event, get_web3_provider, keccak256, get_transaction_receipt, get_alerts, fetch_jwt, decode_jwt, verify_jwt
 from web3 import Web3
 
 web3Provider = Web3(Web3.HTTPProvider(get_json_rpc_url()))

--- a/python-sdk/src/forta_agent/__init__.py
+++ b/python-sdk/src/forta_agent/__init__.py
@@ -7,7 +7,7 @@ from .receipt import Receipt, Log
 from .trace import Trace, TraceAction, TraceResult
 from .event_type import EventType
 from .network import Network
-from .utils import get_json_rpc_url, create_block_event, create_transaction_event, get_web3_provider, keccak256, get_transaction_receipt, get_alerts, fetch_Jwt_token, decode_Jwt_token
+from .utils import get_json_rpc_url, create_block_event, create_transaction_event, get_web3_provider, keccak256, get_transaction_receipt, get_alerts, fetch_Jwt, decode_Jwt
 from web3 import Web3
 
 web3Provider = Web3(Web3.HTTPProvider(get_json_rpc_url()))

--- a/python-sdk/src/forta_agent/utils.py
+++ b/python-sdk/src/forta_agent/utils.py
@@ -130,7 +130,7 @@ def keccak256(val):
     hash.update(bytes(val, encoding='utf-8'))
     return f'0x{hash.hexdigest()}'
 
-def fetch_Jwt_token(claims, expiresAt=None) -> str:
+def fetch_Jwt(claims, expiresAt=None) -> str:
     host_name = 'forta-jwt-provider'
     port = 8515
     path = '/create'
@@ -163,6 +163,6 @@ def fetch_Jwt_token(claims, expiresAt=None) -> str:
             raise err
 
 
-def decode_Jwt_token(token):
+def decode_Jwt(token):
     # Adding need 4 byte for pythons b64decode
     return base64.b64decode(token.split('.')[1] + '==').decode('utf-8')

--- a/python-sdk/src/forta_agent/utils.py
+++ b/python-sdk/src/forta_agent/utils.py
@@ -190,7 +190,7 @@ def verify_jwt(token: str, polygonUrl: str ='https://polygon-rpc.com') -> bool:
         logging.warning('Unexpected signing method: {alg}'.format(alg=alg))
         return False
 
-    currentUnixTime = time.mktime(datetime.utcnow().utctimetuple())
+    currentUnixTime = time.mktime(datetime.datetime.utcnow().utctimetuple())
 
     if expiresAt < currentUnixTime:
         logging.warning('Jwt expired')
@@ -212,6 +212,7 @@ def verify_jwt(token: str, polygonUrl: str ='https://polygon-rpc.com') -> bool:
     areTheyLinked = contract.functions.areTheyLinked(int(botId,0), int(recoveredSignerAddress,0)).call()
     
     return areTheyLinked
+
 class DecodedJwt:
     def __init__(self, dict):
         self.header = dict.get('header')

--- a/python-sdk/src/forta_agent/utils.py
+++ b/python-sdk/src/forta_agent/utils.py
@@ -5,9 +5,16 @@ from jsonc_parser.parser import JsoncParser
 import sha3
 import requests
 import datetime
+import time
+from web3.auto import w3
+from web3 import Web3
+import json
+import logging
 
 from .forta_graphql import AlertsResponse
 
+DISPTACHER_ABI = [{"inputs":[{"internalType":"uint256","name":"agentId","type":"uint256"},{"internalType":"uint256","name":"scannerId","type":"uint256"}],"name":"areTheyLinked","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"view","type":"function"}]
+DISPATCH_CONTRACT = "0xd46832F3f8EA8bDEFe5316696c0364F01b31a573"; # Source: https://docs.forta.network/en/latest/smart-contracts/
 
 def get_web3_provider():
     from . import web3Provider
@@ -130,7 +137,7 @@ def keccak256(val):
     hash.update(bytes(val, encoding='utf-8'))
     return f'0x{hash.hexdigest()}'
 
-def fetch_Jwt(claims, expiresAt=None) -> str:
+def fetch_jwt(claims, expiresAt=None) -> str:
     host_name = 'forta-jwt-provider'
     port = 8515
     path = '/create'
@@ -162,7 +169,61 @@ def fetch_Jwt(claims, expiresAt=None) -> str:
         else:
             raise err
 
+def verify_jwt(token: str, polygonUrl: str ='https://polygon-rpc.com') -> bool:
+    splitJwt = token.split('.')
+    rawHeader = splitJwt[0]
+    rawPayload = splitJwt[1]
 
-def decode_Jwt(token):
+    header = json.loads(base64.urlsafe_b64decode(rawHeader + '==').decode('utf-8'))
+    payload = json.loads(base64.urlsafe_b64decode(rawPayload + '==').decode('utf-8'))
+
+    alg = header['alg']
+    botId = payload['bot-id']
+    expiresAt = payload['exp']
+    signerAddress = payload['sub']
+
+    if (signerAddress is None) or (botId is None):
+        logging.warning('Invalid claim')
+        return False
+    
+    if alg != 'ETH':
+        logging.warning('Unexpected signing method: {alg}'.format(alg=alg))
+        return False
+
+    currentUnixTime = time.mktime(datetime.utcnow().utctimetuple())
+
+    if expiresAt < currentUnixTime:
+        logging.warning('Jwt expired')
+        return False
+
+    msg = '{header}.{payload}'.format(header=rawHeader, payload=rawPayload)
+    msgHash = w3.keccak(text=msg)
+    b64signature = splitJwt[2]
+    signature = base64.urlsafe_b64decode(f'{b64signature}=').hex()
+    recoveredSignerAddress = w3.eth.account.recoverHash(msgHash, signature=signature)
+
+    if recoveredSignerAddress != signerAddress:
+        logging.warn('Signature invalid: expected={signerAddress}, got={recoveredSignerAddress}'.format(signerAddress=signerAddress, recoveredSignerAddress=recoveredSignerAddress))
+        return False
+
+    w3Client = Web3(Web3.HTTPProvider(polygonUrl))
+    contract = w3Client.eth.contract(address=DISPATCH_CONTRACT,abi=DISPTACHER_ABI)
+
+    areTheyLinked = contract.functions.areTheyLinked(int(botId,0), int(recoveredSignerAddress,0)).call()
+    
+    return areTheyLinked
+class DecodedJwt:
+    def __init__(self, dict):
+        self.header = dict.get('header')
+        self.payload = dict.get('payload')
+
+
+def decode_jwt(token):
     # Adding need 4 byte for pythons b64decode
-    return base64.b64decode(token.split('.')[1] + '==').decode('utf-8')
+    header = base64.urlsafe_b64decode(token.split('.')[0] + '==').decode('utf-8')
+    payload = base64.urlsafe_b64decode(token.split('.')[1] + '==').decode('utf-8')
+
+    return DecodedJwt({
+        "header": header,
+        "payload": payload
+    })

--- a/sdk/index.ts
+++ b/sdk/index.ts
@@ -18,7 +18,8 @@ import {
   getTransactionReceipt,
   getAlerts,
   fetchJwtToken,
-  decodeJwtToken
+  decodeJwtToken,
+  verifyJwt
 } from "./utils"
 import awilixConfigureContainer from '../cli/di.container';
 
@@ -104,5 +105,6 @@ export {
   getTransactionReceipt,
   getAlerts,
   fetchJwtToken,
-  decodeJwtToken
+  decodeJwtToken,
+  verifyJwt
  }

--- a/sdk/index.ts
+++ b/sdk/index.ts
@@ -17,8 +17,8 @@ import {
   isPrivateFindings,
   getTransactionReceipt,
   getAlerts,
-  fetchJwtToken,
-  decodeJwtToken,
+  fetchJwt,
+  decodeJwt,
   verifyJwt
 } from "./utils"
 import awilixConfigureContainer from '../cli/di.container';
@@ -104,7 +104,7 @@ export {
   configureContainer,
   getTransactionReceipt,
   getAlerts,
-  fetchJwtToken,
-  decodeJwtToken,
+  fetchJwt,
+  decodeJwt,
   verifyJwt
  }

--- a/sdk/utils.ts
+++ b/sdk/utils.ts
@@ -159,7 +159,7 @@ export const getAlerts = async (query: AlertQueryOptions): Promise<AlertsRespons
   return response.data.data.alerts
 }
 
-export const fetchJwtToken = async (claims: {}, expiresAt?: Date): Promise<{token: string} | null> => {
+export const fetchJwt = async (claims: {}, expiresAt?: Date): Promise<{token: string} | null> => {
   const hostname = 'forta-jwt-provider'
   const port = 8515
   const path = '/create'
@@ -198,7 +198,7 @@ interface DecodedJwt {
   payload: any
 }
 
-export const decodeJwtToken = (token: string): DecodedJwt => {
+export const decodeJwt = (token: string): DecodedJwt => {
 
   const splitJwt = (token).split('.');
   const header = JSON.parse(Buffer.from(splitJwt[0], 'base64').toString())


### PR DESCRIPTION
### Feature work
- [x] Added new method to JS/TS sdk to verify a JWT generated by a scanner
- [x] Added new method to python sdk to verify a JWT generated by a scanner


### Testing
**Manual/Local testing**

In order to validate the verification locally I generated a JWT locally and called the verify method during the initialization of my bot running locally. B/c this bot isn't deployed to validate the happy path locally, during testing I found a bot and an scanner who were linked and hardcoded their addresses in the call to `areTheyLinked` to make sure the smart contract call was valid:

- BotId: 0xe0889c513f9b4fcad87f9c26e9df2e25474223b3b77f7348ee5398bec4e0ee73
- ScannerId: 0xBF536900A88F13D02bc1ff80Af84e480c591001E

