### PR TITLE
Removing console log blocking python fetch jwt

### DIFF
--- a/python-sdk/src/forta_agent/utils.py
+++ b/python-sdk/src/forta_agent/utils.py
@@ -155,7 +155,6 @@ def fetch_jwt(claims, expiresAt=None) -> str:
         response = requests.request("POST", uri, json={'claims': claims})
 
         if response.status_code == 200:
-            print("Got response: " + response.json())
             data = response.json()
             return data.get('token')
 


### PR DESCRIPTION
https://user-images.githubusercontent.com/40375385/194859638-b3b9c195-c5c7-4a81-b826-4f0d7da6f496.mov


Verified python bot is able to fetch a JWT. Here is the bot code used:

```
def handle_block(block_event):
    
    decoded = fetch_Jwt({})
    print('Decoded jwt is {decoded}'.format(decoded=decoded))

    # logging.debug('Is valid Jwt? {isValid}'.format(verify_Jwt(token)))
    
    return []
```