### PR TITLE
return findings for testing

### DIFF
--- a/cli/utils/run.handlers.on.block.spec.ts
+++ b/cli/utils/run.handlers.on.block.spec.ts
@@ -51,7 +51,7 @@ describe("runHandlersOnBlock", () => {
     const mockNetworkId = 1
     mockGetNetworkId.mockReturnValueOnce(mockNetworkId)
     const mockTransaction = { hash: mockTxHash }
-    const mockBlock = { hash: mockBlockHash, number: 7, transactions: [mockTransaction] }
+    const mockBlock = { hash: mockBlockHash, number: 7, transactions: [mockTransaction, mockTransaction] }
     mockGetBlockWithTransactions.mockReturnValueOnce(mockBlock)
     const mockBlockEvent = {}
     mockCreateBlockEvent.mockReturnValueOnce(mockBlockEvent)
@@ -64,7 +64,7 @@ describe("runHandlersOnBlock", () => {
 
     const findings = await runHandlersOnBlock(mockBlockHash)
 
-    expect(findings).toStrictEqual(blockFindings.concat(txFindings))
+    expect(findings).toStrictEqual(blockFindings.concat(txFindings).concat(txFindings))
     expect(mockGetAgentHandlers).toHaveBeenCalledTimes(1)
     expect(mockGetAgentHandlers).toHaveBeenCalledWith()
     expect(mockGetNetworkId).toHaveBeenCalledTimes(1)
@@ -79,9 +79,9 @@ describe("runHandlersOnBlock", () => {
     expect(mockGetLogsForBlock).toHaveBeenCalledWith(mockBlock.number)
     expect(mockGetTraceData).toHaveBeenCalledTimes(1)
     expect(mockGetTraceData).toHaveBeenCalledWith(mockBlock.number)
-    expect(mockCreateTransactionEvent).toHaveBeenCalledTimes(1)
+    expect(mockCreateTransactionEvent).toHaveBeenCalledTimes(2)
     expect(mockCreateTransactionEvent).toHaveBeenCalledWith(mockTransaction, mockBlock, mockNetworkId, [mockTrace], [mockLog])
-    expect(mockHandleTransaction).toHaveBeenCalledTimes(1)
+    expect(mockHandleTransaction).toHaveBeenCalledTimes(2)
     expect(mockHandleTransaction).toHaveBeenCalledWith(mockTxEvent)
   })
 

--- a/cli/utils/run.handlers.on.block.spec.ts
+++ b/cli/utils/run.handlers.on.block.spec.ts
@@ -43,8 +43,10 @@ describe("runHandlersOnBlock", () => {
   })
 
   it("invokes block handlers with block event and transaction handlers with transaction event for each transaction in block", async () => {
-    const mockHandleBlock = jest.fn().mockReturnValue([])
-    const mockHandleTransaction = jest.fn().mockReturnValue([])
+    const blockFindings = getFindingsArray(1, 1)
+    const txFindings = getFindingsArray(1, 1)
+    const mockHandleBlock = jest.fn().mockReturnValue(blockFindings)
+    const mockHandleTransaction = jest.fn().mockReturnValue(txFindings)
     mockGetAgentHandlers.mockReturnValueOnce({ handleBlock: mockHandleBlock, handleTransaction: mockHandleTransaction })
     const mockNetworkId = 1
     mockGetNetworkId.mockReturnValueOnce(mockNetworkId)
@@ -60,8 +62,9 @@ describe("runHandlersOnBlock", () => {
     const mockTxEvent = {}
     mockCreateTransactionEvent.mockReturnValueOnce(mockTxEvent)
 
-    await runHandlersOnBlock(mockBlockHash)
+    const findings = await runHandlersOnBlock(mockBlockHash)
 
+    expect(findings).toStrictEqual(blockFindings.concat(txFindings))
     expect(mockGetAgentHandlers).toHaveBeenCalledTimes(1)
     expect(mockGetAgentHandlers).toHaveBeenCalledWith()
     expect(mockGetNetworkId).toHaveBeenCalledTimes(1)

--- a/cli/utils/run.handlers.on.block.ts
+++ b/cli/utils/run.handlers.on.block.ts
@@ -81,11 +81,12 @@ export function provideRunHandlersOnBlock(
     for (const transaction of block.transactions) {
       const txHash = transaction.hash.toLowerCase()
       const txEvent = createTransactionEvent(transaction, block, networkId, traceMap[txHash], logMap[txHash])
-      txFindings = await handleTransaction(txEvent)
+      const findings = await handleTransaction(txEvent)
+      txFindings.push(...findings)
 
-      assertFindings(txFindings)
+      assertFindings(findings)
 
-      console.log(`${txFindings.length} findings for transaction ${transaction.hash} ${txFindings}`)
+      console.log(`${findings.length} findings for transaction ${transaction.hash} ${findings}`)
     }
 
     return blockFindings.concat(txFindings)

--- a/cli/utils/run.handlers.on.block.ts
+++ b/cli/utils/run.handlers.on.block.ts
@@ -1,4 +1,4 @@
-import { Trace } from "../../sdk";
+import { Finding, Trace } from "../../sdk";
 import { GetAgentHandlers } from "./get.agent.handlers";
 import { GetTraceData } from "./get.trace.data";
 import { assertExists, assertFindings, CreateBlockEvent, CreateTransactionEvent } from ".";
@@ -7,7 +7,7 @@ import { GetBlockWithTransactions } from "./get.block.with.transactions";
 import { JsonRpcLog } from "./get.transaction.receipt";
 import { GetLogsForBlock } from "./get.logs.for.block";
 
-export type RunHandlersOnBlock = (blockHashOrNumber: string | number) => Promise<void>
+export type RunHandlersOnBlock = (blockHashOrNumber: string | number) => Promise<Finding[]>
 
 export function provideRunHandlersOnBlock(
   getAgentHandlers: GetAgentHandlers,
@@ -38,17 +38,20 @@ export function provideRunHandlersOnBlock(
       getBlockWithTransactions(blockHashOrNumber)
     ]) 
 
+    let blockFindings: Finding[] = []
+    let txFindings: Finding[] = []
+    
     // run block handler
     if (handleBlock) {
       const blockEvent = createBlockEvent(block, networkId)
-      const findings = await handleBlock(blockEvent)
+      blockFindings = await handleBlock(blockEvent)
 
-      assertFindings(findings)
+      assertFindings(blockFindings)
       
-      console.log(`${findings.length} findings for block ${block.hash} ${findings}`)
+      console.log(`${blockFindings.length} findings for block ${block.hash} ${blockFindings}`)
     }
 
-    if (!handleTransaction) return
+    if (!handleTransaction) return blockFindings
     
     const blockNumber = parseInt(block.number)
     const [logs, traces] = await Promise.all([
@@ -78,12 +81,14 @@ export function provideRunHandlersOnBlock(
     for (const transaction of block.transactions) {
       const txHash = transaction.hash.toLowerCase()
       const txEvent = createTransactionEvent(transaction, block, networkId, traceMap[txHash], logMap[txHash])
-      const findings = await handleTransaction(txEvent)
+      txFindings = await handleTransaction(txEvent)
 
-      assertFindings(findings)
+      assertFindings(txFindings)
 
-      console.log(`${findings.length} findings for transaction ${transaction.hash} ${findings}`)
+      console.log(`${txFindings.length} findings for transaction ${transaction.hash} ${txFindings}`)
     }
+
+    return blockFindings.concat(txFindings)
   }
 }
 

--- a/cli/utils/run.handlers.on.transaction.spec.ts
+++ b/cli/utils/run.handlers.on.transaction.spec.ts
@@ -39,7 +39,8 @@ describe("runHandlersOnTransaction", () => {
   })
 
   it("invokes transaction handler with transaction event", async () => {
-    const mockHandleTransaction = jest.fn().mockReturnValue([])
+    const txFindings = getFindingsArray(1, 1)
+    const mockHandleTransaction = jest.fn().mockReturnValue(txFindings)
     mockGetAgentHandlers.mockReturnValueOnce({ handleTransaction: mockHandleTransaction })
     const mockNetworkId = 1
     mockGetNetworkId.mockReturnValueOnce(mockNetworkId)
@@ -54,8 +55,9 @@ describe("runHandlersOnTransaction", () => {
     const mockTxEvent = {}
     mockCreateTransactionEvent.mockReturnValueOnce(mockTxEvent)
 
-    await runHandlersOnTransaction(mockTxHash)
+    const findings = await runHandlersOnTransaction(mockTxHash)
 
+    expect(findings).toStrictEqual(txFindings)
     expect(mockGetAgentHandlers).toHaveBeenCalledTimes(1)
     expect(mockGetAgentHandlers).toHaveBeenCalledWith()
     expect(mockGetNetworkId).toHaveBeenCalledTimes(1)

--- a/cli/utils/run.handlers.on.transaction.ts
+++ b/cli/utils/run.handlers.on.transaction.ts
@@ -1,11 +1,12 @@
 import { assertExists, assertFindings, CreateTransactionEvent } from ".";
+import { Finding } from "../../sdk";
 import { GetAgentHandlers } from "./get.agent.handlers";
 import { GetBlockWithTransactions } from "./get.block.with.transactions";
 import { GetNetworkId } from "./get.network.id";
 import { GetTraceData } from "./get.trace.data";
 import { GetTransactionReceipt } from "./get.transaction.receipt";
 
-export type RunHandlersOnTransaction = (txHash: string) => Promise<void>
+export type RunHandlersOnTransaction = (txHash: string) => Promise<Finding[]>
 
 export function provideRunHandlersOnTransaction(
   getAgentHandlers: GetAgentHandlers,
@@ -43,5 +44,7 @@ export function provideRunHandlersOnTransaction(
     assertFindings(findings)
 
     console.log(`${findings.length} findings for transaction ${txHash} ${findings}`)
+
+    return findings
   }
 }


### PR DESCRIPTION
as per user request, we are returning the findings array from the `runHandlersOnBlock` and `runHandlersOnTransaction` util methods so they can be used for testing