### PR TITLE
Add labels to findings

### DIFF
--- a/cli/commands/run/server/agent.proto
+++ b/cli/commands/run/server/agent.proto
@@ -41,6 +41,38 @@ message EvaluateBlockRequest {
   BlockEvent event = 2;
 }
 
+message Label {
+  enum EntityType {
+    UNKNOWN_ENTITY_TYPE = 0;
+    ADDRESS = 1;
+    TRANSACTION = 2;
+    BLOCK = 3;
+    URL = 4;
+  }
+
+  enum LabelType {
+    UNKNOWN_LABEL_TYPE = 0;
+    CUSTOM = 1;
+    PROTOCOL_ATTACK = 2;
+    SCAM = 3;
+    RUG_PULL = 4;
+    BRIDGE = 5;
+    MIXER = 6;
+    DEX = 7;
+    CEX = 8;
+    ATTACKER = 9;
+    VICTIM = 10;
+    EOA = 11;
+    CONTRACT = 12;
+  }
+
+  EntityType entityType = 1;
+  string entity = 2;
+  LabelType labelType = 3;
+  float confidence = 4;
+  string customValue = 5;
+}
+
 message Finding {
   enum Severity {
     UNKNOWN = 0;
@@ -69,6 +101,7 @@ message Finding {
   string everestId = 8;
   bool private = 9;
   repeated string addresses = 10;
+  repeated Label labels = 11;
 }
 
 message EvaluateTxResponse {

--- a/python-sdk/src/forta_agent/__init__.py
+++ b/python-sdk/src/forta_agent/__init__.py
@@ -1,4 +1,5 @@
 from .finding import Finding, FindingSeverity, FindingType
+from .label import Label, LabelType, EntityType
 from .block_event import BlockEvent
 from .transaction_event import TransactionEvent, TxEventBlock
 from .block import Block

--- a/python-sdk/src/forta_agent/finding.py
+++ b/python-sdk/src/forta_agent/finding.py
@@ -35,6 +35,7 @@ class Finding:
         self.type = dict['type']
         self.metadata = dict.get('metadata')
         self.addresses = dict.get('addresses')
+        self.labels = dict.get('labels')
 
     def toJson(self):
         d = dict(self.__dict__, **{'alertId': self.alert_id})

--- a/python-sdk/src/forta_agent/label.py
+++ b/python-sdk/src/forta_agent/label.py
@@ -1,0 +1,38 @@
+from enum import IntEnum
+from .utils import assert_enum_value_in_dict, assert_non_empty_string_in_dict
+
+class LabelType(IntEnum):
+    Unknown = 0
+    Custom = 1
+    ProtocolAttack = 2
+    Scam = 3
+    RugPull = 4
+    Bridge = 5
+    Mixer = 6
+    Dex = 7
+    Cex = 8
+    Attacker = 9
+    Victim = 10
+    Eoa = 11
+    Contract = 12
+
+class EntityType(IntEnum):
+    Unknown = 0
+    Address = 1
+    Transaction = 2
+    Block = 3
+    Url = 4
+
+class Label:
+    def __init__(self, dict):
+        assert_enum_value_in_dict(dict, 'entity_type', EntityType)
+        assert_enum_value_in_dict(dict, 'label_type', LabelType)
+        assert_non_empty_string_in_dict(dict, 'entity')
+        assert_non_empty_string_in_dict(dict, 'confidence')
+        assert_non_empty_string_in_dict(dict, 'custom_value')
+        self.entity = dict['entity']
+        self.confidence = dict['confidence']
+        self.customValue = dict['custom_value']
+        self.entity_type = dict['entity_type']
+        self.label_type = dict['label_type']
+

--- a/python-sdk/src/forta_agent/label.py
+++ b/python-sdk/src/forta_agent/label.py
@@ -28,8 +28,6 @@ class Label:
         assert_enum_value_in_dict(dict, 'entity_type', EntityType)
         assert_enum_value_in_dict(dict, 'label_type', LabelType)
         assert_non_empty_string_in_dict(dict, 'entity')
-        assert_non_empty_string_in_dict(dict, 'confidence')
-        assert_non_empty_string_in_dict(dict, 'custom_value')
         self.entity = dict['entity']
         self.confidence = dict['confidence']
         self.customValue = dict['custom_value']

--- a/sdk/finding.ts
+++ b/sdk/finding.ts
@@ -1,3 +1,4 @@
+import { Label } from "./label"
 import { assertIsFromEnum, assertIsNonEmptyString } from "./utils"
 
 export enum FindingSeverity {
@@ -26,6 +27,7 @@ type FindingInput = {
   type: FindingType,
   metadata?: { [key: string]: string},
   addresses?: string[],
+  labels?: Label[]
 }
 
 export class Finding {
@@ -37,7 +39,8 @@ export class Finding {
     readonly severity: FindingSeverity,
     readonly type: FindingType,
     readonly metadata: { [key: string]: string},
-    readonly addresses: string[]
+    readonly addresses: string[],
+    readonly labels: Label[]
   ) {}
 
   toString() {
@@ -60,7 +63,8 @@ export class Finding {
     severity,
     type,
     metadata = {},
-    addresses = []
+    addresses = [],
+    labels = []
   }: FindingInput) {
     assertIsNonEmptyString(name, 'name')
     assertIsNonEmptyString(description, 'description')
@@ -70,6 +74,6 @@ export class Finding {
     assertIsFromEnum(type, FindingType, 'type')
     // TODO assert metadata keys and values are strings
 
-    return new Finding(name, description, alertId, protocol, severity, type, metadata, addresses)
+    return new Finding(name, description, alertId, protocol, severity, type, metadata, addresses, labels)
   }
 }

--- a/sdk/index.ts
+++ b/sdk/index.ts
@@ -1,5 +1,6 @@
 import { ethers } from "ethers"
 import { Finding, FindingSeverity, FindingType } from "./finding"
+import { Label, LabelType, EntityType } from "./label"
 import { BlockEvent } from "./block.event"
 import { Block } from "./block"
 import { TransactionEvent, TxEventBlock, LogDescription } from "./transaction.event"
@@ -79,6 +80,9 @@ export {
   Finding,
   FindingSeverity,
   FindingType,
+  Label,
+  LabelType,
+  EntityType,
   BlockEvent,
   TransactionEvent,
   TxEventBlock,

--- a/sdk/label.ts
+++ b/sdk/label.ts
@@ -1,0 +1,32 @@
+
+export enum LabelType {
+    Unknown,
+    Custom,
+    ProtocolAttack,
+    Scam,
+    RugPull,
+    Bridge,
+    Mixer,
+    Dex,
+    Cex,
+    Attacker,
+    Victim,
+    Eoa,
+    Contract
+}
+
+export enum EntityType {
+    Unknown,
+    Address,
+    Transaction,
+    Block,
+    Url
+}
+
+export interface Label {
+    entityType: EntityType,
+    entity: string,
+    labelType: LabelType,
+    confidence: number,
+    customValue: string
+}


### PR DESCRIPTION
This lets a bot developer map entities (address, transaction, block, url, etc..) to labels to aid in modeling relationships needed for fraud/exploit/risk detection.

Here is the bot I used to test this change locally

```
from forta_agent import Finding, FindingType, FindingSeverity, Label, LabelType, EntityType

ERC20_TRANSFER_EVENT = '{"name":"Transfer","type":"event","anonymous":false,"inputs":[{"indexed":true,"name":"from","type":"address"},{"indexed":true,"name":"to","type":"address"},{"indexed":false,"name":"value","type":"uint256"}]}'
TETHER_ADDRESS = '0xdAC17F958D2ee523a2206206994597C13D831ec7'
TETHER_DECIMALS = 6
findings_count = 0


def handle_transaction(transaction_event):
    findings = []

    # limiting this agent to emit only 5 findings so that the alert feed is not spammed
    global findings_count
    if findings_count >= 5:
        return findings

    # filter the transaction logs for any Tether transfers
    tether_transfer_events = transaction_event.filter_log(
        ERC20_TRANSFER_EVENT, TETHER_ADDRESS)

    for transfer_event in tether_transfer_events:
        # extract transfer event arguments
        to = transfer_event['args']['to']
        from_ = transfer_event['args']['from']
        value = transfer_event['args']['value']
        # shift decimals of transfer value
        normalized_value = value / 10 ** TETHER_DECIMALS

        # if more than 10,000 Tether were transferred, report it
        if normalized_value > 10000:
            findings.append(Finding({
                'name': 'High Tether Transfer',
                'description': f'High amount of USDT transferred: {normalized_value}',
                'alert_id': 'FORTA-1',
                'severity': FindingSeverity.Low,
                'type': FindingType.Info,
                'metadata': {
                    'to': to,
                    'from': from_,
                },
                'labels': [
                    Label({
                        'entity': "Large Tether Owner",
                        'entity_type': EntityType.Address,
                        'label_type': LabelType.Custom,
                        'confidence': 40,
                        'custom_value': "some custom value"
                    })
                ]
            }))
            findings_count += 1

    return findings


```