### PR TITLE
Add good as a label type

### DIFF
--- a/cli/commands/run/server/agent.proto
+++ b/cli/commands/run/server/agent.proto
@@ -78,6 +78,7 @@ message Label {
     VICTIM = 10;
     EOA = 11;
     CONTRACT = 12;
+    LABEL = 13;
   }
 
   EntityType entityType = 1;

--- a/cli/commands/run/server/agent.proto
+++ b/cli/commands/run/server/agent.proto
@@ -78,7 +78,7 @@ message Label {
     VICTIM = 10;
     EOA = 11;
     CONTRACT = 12;
-    LABEL = 13;
+    GOOD = 13;
   }
 
   EntityType entityType = 1;

--- a/python-sdk/src/forta_agent/label.py
+++ b/python-sdk/src/forta_agent/label.py
@@ -15,6 +15,7 @@ class LabelType(IntEnum):
     Victim = 10
     Eoa = 11
     Contract = 12
+    Good = 13
 
 class EntityType(IntEnum):
     Unknown = 0

--- a/sdk/label.ts
+++ b/sdk/label.ts
@@ -12,7 +12,8 @@ export enum LabelType {
     Attacker,
     Victim,
     Eoa,
-    Contract
+    Contract,
+    Good
 }
 
 export enum EntityType {


### PR DESCRIPTION
This aligns the sdk with the latest LabelType specification here:
https://github.com/forta-network/forta-core-go/blob/master/protocol/alert.proto#L75