### PR TITLE
make alertId optional in subscription config

### DIFF
--- a/sdk/initialize.response.ts
+++ b/sdk/initialize.response.ts
@@ -1,6 +1,7 @@
 export interface BotSubscription {
   botId: string;
-  alertId: string;
+  alertId?: string;
+  alertIds?: string[];
 }
 
 export interface AlertConfig {


### PR DESCRIPTION
when specifying which bots to subscribe to, the `alertId` field is now optional in the proto. also, another optional `alertIds` field was added