### PR TITLE
allow runFile to specify hashes

### DIFF
--- a/cli/commands/run/run.file.spec.ts
+++ b/cli/commands/run/run.file.spec.ts
@@ -1,62 +1,90 @@
-import { provideRunFile, RunFile } from "./run.file"
+import { provideRunFile, RunFile } from "./run.file";
 
 describe("runFile", () => {
-  let runFile: RunFile
-  const mockGetAgentHandlers = jest.fn()
-  const mockGetJsonFile = jest.fn()
-  const mockFilePath = "some/file/path"
+  let runFile: RunFile;
+  const mockGetAgentHandlers = jest.fn();
+  const mockGetJsonFile = jest.fn();
+  const mockRunHandlersOnBlock = jest.fn();
+  const mockRunHandlersOnTransaction = jest.fn();
+  const mockRunHandlersOnAlert = jest.fn();
+  const mockRunSequence = jest.fn();
+  const mockFilePath = "some/file/path";
 
   beforeAll(() => {
-    runFile = provideRunFile(mockGetAgentHandlers, mockGetJsonFile)
-  })
+    runFile = provideRunFile(
+      mockGetAgentHandlers,
+      mockGetJsonFile,
+      mockRunHandlersOnBlock,
+      mockRunHandlersOnTransaction,
+      mockRunHandlersOnAlert,
+      mockRunSequence
+    );
+  });
 
   it("throws error if no handlers found", async () => {
-    mockGetAgentHandlers.mockReturnValueOnce({})
+    mockGetAgentHandlers.mockReturnValueOnce({});
 
     try {
-      await runFile(mockFilePath)
+      await runFile(mockFilePath);
     } catch (e) {
-      expect(e.message).toEqual('no block/transaction/alert handler found')
+      expect(e.message).toEqual("no block/transaction/alert handler found");
     }
 
-    expect(mockGetAgentHandlers).toHaveBeenCalledTimes(1)
-  })
+    expect(mockGetAgentHandlers).toHaveBeenCalledTimes(1);
+  });
 
   it("runs handlers against each event provided in file", async () => {
-    mockGetAgentHandlers.mockReset()
-    const mockHandleBlock = jest.fn().mockReturnValue([])
-    const mockHandleTransaction = jest.fn().mockReturnValue([])
-    const mockHandleAlert = jest.fn().mockReturnValue([])
+    mockGetAgentHandlers.mockReset();
+    const mockHandleBlock = jest.fn().mockReturnValue([]);
+    const mockHandleTransaction = jest.fn().mockReturnValue([]);
+    const mockHandleAlert = jest.fn().mockReturnValue([]);
     mockGetAgentHandlers.mockReturnValueOnce({
       handleBlock: mockHandleBlock,
       handleTransaction: mockHandleTransaction,
-      handleAlert: mockHandleAlert
-    })
-    const blockEvent1 = { "hash": "0xabc" }
-    const blockEvent2 = { "hash": "0xdef" }
-    const txEvent1 = { transaction: { "hash": "0x123" } }
-    const txEvent2 = { transaction: { "hash": "0x456" } }
-    const alertEvent1 = { alert: { "hash": "0x123" } }
-    const alertEvent2 = { alert: { "hash": "0x456" } }
+      handleAlert: mockHandleAlert,
+    });
+    const blockEvent1 = { hash: "0xabc" };
+    const blockEvent2 = { hash: "0xdef" };
+    const blockEvent3 = "0xghi";
+    const blockEvent4 = 1234;
+    const txEvent1 = { transaction: { hash: "0x123" } };
+    const txEvent2 = { transaction: { hash: "0x456" } };
+    const txEvent3 = "0x789";
+    const alertEvent1 = { alert: { hash: "0x123" } };
+    const alertEvent2 = { alert: { hash: "0x456" } };
+    const alertEvent3 = "0x328";
+    const sequenceEvent1 = "a,b,c";
+    const sequenceEvent2 = "d";
     mockGetJsonFile.mockReturnValueOnce({
-      blockEvents: [blockEvent1, blockEvent2],
-      transactionEvents: [txEvent1, txEvent2],
-      alertEvents: [alertEvent1, alertEvent2],
-    })
+      blockEvents: [blockEvent1, blockEvent2, blockEvent3, blockEvent4],
+      transactionEvents: [txEvent1, txEvent2, txEvent3],
+      alertEvents: [alertEvent1, alertEvent2, alertEvent3],
+      sequenceEvents: [sequenceEvent1, sequenceEvent2],
+    });
 
-    await runFile(mockFilePath)
+    await runFile(mockFilePath);
 
-    expect(mockGetAgentHandlers).toHaveBeenCalledTimes(1)
-    expect(mockGetJsonFile).toHaveBeenCalledTimes(1)
-    expect(mockGetJsonFile).toHaveBeenCalledWith(mockFilePath)
-    expect(mockHandleBlock).toHaveBeenCalledTimes(2)
-    expect(mockHandleBlock).toHaveBeenNthCalledWith(1, blockEvent1)
-    expect(mockHandleBlock).toHaveBeenNthCalledWith(2, blockEvent2)
-    expect(mockHandleTransaction).toHaveBeenCalledTimes(2)
-    expect(mockHandleTransaction).toHaveBeenNthCalledWith(1, txEvent1)
-    expect(mockHandleTransaction).toHaveBeenNthCalledWith(2, txEvent2)
-    expect(mockHandleAlert).toHaveBeenCalledTimes(2)
-    expect(mockHandleAlert).toHaveBeenNthCalledWith(1, alertEvent1)
-    expect(mockHandleAlert).toHaveBeenNthCalledWith(2, alertEvent2)
-  })
-})
+    expect(mockGetAgentHandlers).toHaveBeenCalledTimes(1);
+    expect(mockGetJsonFile).toHaveBeenCalledTimes(1);
+    expect(mockGetJsonFile).toHaveBeenCalledWith(mockFilePath);
+    expect(mockHandleBlock).toHaveBeenCalledTimes(2);
+    expect(mockHandleBlock).toHaveBeenNthCalledWith(1, blockEvent1);
+    expect(mockHandleBlock).toHaveBeenNthCalledWith(2, blockEvent2);
+    expect(mockRunHandlersOnBlock).toHaveBeenCalledTimes(2);
+    expect(mockRunHandlersOnBlock).toHaveBeenNthCalledWith(1, blockEvent3);
+    expect(mockRunHandlersOnBlock).toHaveBeenNthCalledWith(2, blockEvent4);
+    expect(mockHandleTransaction).toHaveBeenCalledTimes(2);
+    expect(mockHandleTransaction).toHaveBeenNthCalledWith(1, txEvent1);
+    expect(mockHandleTransaction).toHaveBeenNthCalledWith(2, txEvent2);
+    expect(mockRunHandlersOnTransaction).toHaveBeenCalledTimes(1);
+    expect(mockRunHandlersOnTransaction).toHaveBeenNthCalledWith(1, txEvent3);
+    expect(mockHandleAlert).toHaveBeenCalledTimes(2);
+    expect(mockHandleAlert).toHaveBeenNthCalledWith(1, alertEvent1);
+    expect(mockHandleAlert).toHaveBeenNthCalledWith(2, alertEvent2);
+    expect(mockRunHandlersOnAlert).toHaveBeenCalledTimes(1);
+    expect(mockRunHandlersOnAlert).toHaveBeenNthCalledWith(1, alertEvent3);
+    expect(mockRunSequence).toHaveBeenCalledTimes(2);
+    expect(mockRunSequence).toHaveBeenNthCalledWith(1, sequenceEvent1);
+    expect(mockRunSequence).toHaveBeenNthCalledWith(2, sequenceEvent2);
+  });
+});

--- a/cli/commands/run/run.file.ts
+++ b/cli/commands/run/run.file.ts
@@ -1,15 +1,27 @@
 import { assertExists, GetJsonFile } from '../../utils';
 import { GetAgentHandlers } from '../../utils/get.agent.handlers';
+import { RunHandlersOnAlert } from '../../utils/run.handlers.on.alert';
+import { RunHandlersOnBlock } from '../../utils/run.handlers.on.block';
+import { RunHandlersOnTransaction } from '../../utils/run.handlers.on.transaction';
+import { RunSequence } from './run.sequence';
 
 // runs agent handlers against a specified json file with test data
 export type RunFile = (filePath: string) => Promise<void>
 
 export function provideRunFile(
   getAgentHandlers: GetAgentHandlers,
-  getJsonFile: GetJsonFile
+  getJsonFile: GetJsonFile,
+  runHandlersOnBlock: RunHandlersOnBlock,
+  runHandlersOnTransaction: RunHandlersOnTransaction,
+  runHandlersOnAlert: RunHandlersOnAlert,
+  runSequence: RunSequence
 ): RunFile {
   assertExists(getAgentHandlers, 'getAgentHandlers')
   assertExists(getJsonFile, 'getJsonFile')
+  assertExists(runHandlersOnBlock, 'runHandlersOnBlock')
+  assertExists(runHandlersOnTransaction, 'runHandlersOnTransaction')
+  assertExists(runHandlersOnAlert, 'runHandlersOnAlert')
+  assertExists(runSequence, 'runSequence')
 
   return async function runFile(filePath: string) {
     const { handleBlock, handleTransaction, handleAlert } = await getAgentHandlers()
@@ -18,29 +30,47 @@ export function provideRunFile(
     }
     
     console.log('parsing file data...')
-    const { transactionEvents, blockEvents, alertEvents } = getJsonFile(filePath)
+    const { transactionEvents, blockEvents, alertEvents, sequenceEvents } = getJsonFile(filePath)
 
     if (handleBlock && blockEvents?.length) {
       console.log('running block events...')
       for (const blockEvent of blockEvents) {
-        const findings = await handleBlock(blockEvent)
-        console.log(`${findings.length} findings for block ${blockEvent.hash} ${findings}`)
+        if (typeof blockEvent === 'string' || typeof blockEvent === 'number') {
+          await runHandlersOnBlock(blockEvent)
+        } else {
+          const findings = await handleBlock(blockEvent)
+          console.log(`${findings.length} findings for block ${blockEvent.hash} ${findings}`)
+        }
       }
     }
 
     if (handleTransaction && transactionEvents?.length) {
       console.log('running transaction events...')
       for (const transactionEvent of transactionEvents) {
-        const findings = await handleTransaction(transactionEvent)
-        console.log(`${findings.length} findings for transaction ${transactionEvent.transaction.hash} ${findings}`)
+        if (typeof transactionEvent === 'string') {
+          await runHandlersOnTransaction(transactionEvent)
+        } else {
+          const findings = await handleTransaction(transactionEvent)
+          console.log(`${findings.length} findings for transaction ${transactionEvent.transaction.hash} ${findings}`)
+        }
       }
     }
 
     if (handleAlert && alertEvents?.length) {
       console.log('running alert events...')
       for (const alertEvent of alertEvents) {
-        const findings = await handleAlert(alertEvent)
-        console.log(`${findings.length} findings for alert ${alertEvent.alert.hash} ${findings}`)
+        if (typeof alertEvent === 'string') {
+          await runHandlersOnAlert(alertEvent)
+        } else {
+          const findings = await handleAlert(alertEvent)
+          console.log(`${findings.length} findings for alert ${alertEvent.alert.hash} ${findings}`)
+        }
+      }
+    }
+
+    if (sequenceEvents?.length) {
+      for (const sequence of sequenceEvents) {
+        await runSequence(sequence)
       }
     }
   }


### PR DESCRIPTION
updating the `run --file` command to allow specifying block/tx/alert hashes (instead of just json objects), as well as sequences. this will help Christian test sequences of events that are too long to specify on the commandline