### PR TITLE
Fix the CLI container to load the JSON RPC URL from env 

### DIFF
--- a/cli/di.container.ts
+++ b/cli/di.container.ts
@@ -245,12 +245,17 @@ export default function configureContainer(args: any = {}) {
     }),
 
     jsonRpcUrl: asFunction((fortaConfig: FortaConfig) => {
-      const jsonRpcUrl = fortaConfig.jsonRpcUrl || "https://cloudflare-eth.com/"
-      if (!jsonRpcUrl.startsWith("http")) {
-        throw new Error(`jsonRpcUrl must begin with http(s)`)
+      if (process.env.JSON_RPC_HOST) {
+        jsonRpcUrl = `https://${process.env.JSON_RPC_HOST}${process.env.JSON_RPC_PORT ? `:${process.env.JSON_RPC_PORT}` : ''}`
+      } else {
+        jsonRpcUrl = fortaConfig.jsonRpcUrl || "https://cloudflare-eth.com/";
       }
-      return jsonRpcUrl
-    }),
+      if (!jsonRpcUrl.startsWith("http")) {
+        throw new Error(`jsonRpcUrl must begin with http(s)`);
+      }
+      return jsonRpcUrl;
+    });
+
     ethersProvider: asFunction((jsonRpcUrl: string) =>  new ethers.providers.JsonRpcProvider(jsonRpcUrl)).singleton(),
     ethersAgentRegistryProvider: asFunction((agentRegistryJsonRpcUrl: string) => new ethers.providers.JsonRpcProvider(agentRegistryJsonRpcUrl)).singleton(),
 

--- a/python-sdk/src/forta_agent/utils.py
+++ b/python-sdk/src/forta_agent/utils.py
@@ -43,7 +43,7 @@ def get_forta_config():
 
 def get_json_rpc_url():
     if 'JSON_RPC_HOST' in os.environ:
-        return f'http://{os.environ["JSON_RPC_HOST"]}{":"+os.environ["JSON_RPC_PORT"] if "JSON_RPC_PORT" in os.environ else ""}'
+        return f'https://{os.environ["JSON_RPC_HOST"]}{":"+os.environ["JSON_RPC_PORT"] if "JSON_RPC_PORT" in os.environ else ""}'
 
     config = get_forta_config()
     if "jsonRpcUrl" not in config:

--- a/sdk/utils.ts
+++ b/sdk/utils.ts
@@ -51,7 +51,7 @@ const getFortaConfig: () => FortaConfig = () => {
 export const getJsonRpcUrl = () => {
   // if rpc url provided by Forta Scanner i.e. in production
   if (process.env.JSON_RPC_HOST) {
-    return `http://${process.env.JSON_RPC_HOST}${process.env.JSON_RPC_PORT ? `:${process.env.JSON_RPC_PORT}` : ''}`
+    return `https://${process.env.JSON_RPC_HOST}${process.env.JSON_RPC_PORT ? `:${process.env.JSON_RPC_PORT}` : ''}`
   }
   
   // else, use the rpc url from forta.config.json


### PR DESCRIPTION
There is a bug while reading up the environment variable for JSON RPC.
The current implementation just checks the URL from `forta.config.json` but this adds the ability to load from the ENV variable.

Currently, all the environment HOST variables are defaulted to `http://` , Can we moved them to `https://` or just fully expect the jsonRPCUrl environment value instead of appending `https://`