### PR TITLE
increase time between alert queries

### DIFF
--- a/cli/commands/run/run.live.spec.ts
+++ b/cli/commands/run/run.live.spec.ts
@@ -12,6 +12,11 @@ describe("runLive", () => {
   const mockRunHandlersOnAlert = jest.fn();
   const mockSleep = jest.fn();
   const mockShouldContinuePolling = jest.fn();
+  const mockInitializeResponse = {
+    alertConfig: {
+      subscriptions: [{ botId: "0x123", alertId: "ALERT-1" }],
+    },
+  };
   const latestBlockNumber = 1000;
   const systemTime = new Date();
 
@@ -80,11 +85,6 @@ describe("runLive", () => {
   });
 
   it("processes new blocks on following iterations", async () => {
-    const mockInitializeResponse = {
-      alertConfig: {
-        subscriptions: [{ botId: "0x123", alertId: "ALERT-1" }],
-      },
-    };
     mockGetAgentHandlers.mockReturnValue({
       handleTransaction: jest.fn(),
       handleAlert: jest.fn(),
@@ -115,10 +115,10 @@ describe("runLive", () => {
     expect(mockRunHandlersOnBlock).toHaveBeenCalledWith(latestBlockNumber + 1);
     expect(mockRunHandlersOnBlock).toHaveBeenCalledWith(latestBlockNumber + 2);
     expect(mockRunHandlersOnBlock).toHaveBeenCalledWith(latestBlockNumber + 3);
-    expect(mockGetSubscriptionAlerts).toHaveBeenCalledTimes(2);
+    expect(mockGetSubscriptionAlerts).toHaveBeenCalledTimes(1);
     expect(mockGetSubscriptionAlerts).toHaveBeenCalledWith(
       mockInitializeResponse.alertConfig.subscriptions,
-      systemTime
+      new Date(systemTime.getTime() - 60000)
     );
     expect(mockRunHandlersOnAlert).toHaveBeenCalledTimes(1);
     expect(mockRunHandlersOnAlert).toHaveBeenCalledWith(mockAlert);

--- a/cli/utils/get.subscription.alerts.spec.ts
+++ b/cli/utils/get.subscription.alerts.spec.ts
@@ -85,13 +85,13 @@ describe("getSubscriptionAlerts", () => {
       botIds: ["0xbot1", "0xbot2"],
       alertIds: ["ALERT-1", "ALERT-2"],
       createdSince: 0,
-      first: 100,
+      first: 1000,
     });
     expect(mockGetAlerts).toHaveBeenCalledWith({
       botIds: ["0xbot1", "0xbot2"],
       alertIds: ["ALERT-1", "ALERT-2"],
       createdSince: 0,
-      first: 100,
+      first: 1000,
       startingCursor: mockEndCursor,
     });
     expect(mockGetAlerts).toHaveBeenCalledWith({
@@ -99,7 +99,7 @@ describe("getSubscriptionAlerts", () => {
       alertIds: ["ALERT-3", "ALERT-4"],
       createdSince: 0,
       chainId: 137,
-      first: 100,
+      first: 1000,
     });
     jest.useRealTimers();
   });

--- a/cli/utils/get.subscription.alerts.ts
+++ b/cli/utils/get.subscription.alerts.ts
@@ -65,7 +65,7 @@ async function runQuery(
     query = {
       botIds: Array.from(botIds),
       createdSince: now.getTime() - createdSince.getTime(),
-      first: 100,
+      first: 1000,
       startingCursor: response?.pageInfo.endCursor,
     };
     if (chainId > 0) {


### PR DESCRIPTION
when running a bot locally that has subscribed to other bots (using `npm run`), we currently query alerts whenever theres a new block which comes out to about 15-20 seconds. this is too recent a time period to query since indexing alerts can take up to a minute. with this change, we wait at least one minute before querying for alerts (which is what scan node does)