### PR TITLE
add retry logic when running locally

### DIFF
--- a/cli/commands/run/run.live.spec.ts
+++ b/cli/commands/run/run.live.spec.ts
@@ -2,10 +2,8 @@ import { provideRunLive, RunLive } from "./run.live";
 
 describe("runLive", () => {
   let runLive: RunLive;
-  const mockEthersProvider = {
-    getBlockNumber: jest.fn(),
-    getNetwork: jest.fn(),
-  } as any;
+  const mockGetNetworkId = jest.fn();
+  const mockGetLatestBlockNumber = jest.fn();
   const mockGetAgentHandlers = jest.fn();
   const mockGetSubscriptionAlerts = jest.fn();
   const mockRunHandlersOnBlock = jest.fn();
@@ -25,19 +23,20 @@ describe("runLive", () => {
     mockGetSubscriptionAlerts.mockReset();
     mockRunHandlersOnBlock.mockReset();
     mockRunHandlersOnAlert.mockReset();
-    mockEthersProvider.getBlockNumber.mockReset();
-    mockEthersProvider.getNetwork.mockReset();
+    mockGetLatestBlockNumber.mockReset();
+    mockGetNetworkId.mockReset();
     mockSleep.mockReset();
     mockShouldContinuePolling.mockReset();
   };
 
-  const blockChainNetwork = { chainId: 1 };
+  const mockNetworkId = 1;
 
   beforeAll(() => {
     runLive = provideRunLive(
       mockGetAgentHandlers,
       mockGetSubscriptionAlerts,
-      mockEthersProvider,
+      mockGetNetworkId,
+      mockGetLatestBlockNumber,
       mockRunHandlersOnBlock,
       mockRunHandlersOnAlert,
       mockSleep
@@ -70,15 +69,18 @@ describe("runLive", () => {
     mockShouldContinuePolling
       .mockReturnValueOnce(true)
       .mockReturnValueOnce(false);
-    mockEthersProvider.getBlockNumber.mockReturnValueOnce(latestBlockNumber);
-    mockEthersProvider.getNetwork.mockReturnValueOnce(blockChainNetwork);
+    mockGetLatestBlockNumber.mockReturnValueOnce(latestBlockNumber);
+    mockGetNetworkId.mockReturnValueOnce(mockNetworkId);
 
     await runLive(mockShouldContinuePolling);
 
-    expect(mockEthersProvider.getBlockNumber).toHaveBeenCalledTimes(1);
-    expect(mockEthersProvider.getBlockNumber).toHaveBeenCalledWith();
+    expect(mockGetLatestBlockNumber).toHaveBeenCalledTimes(1);
+    expect(mockGetLatestBlockNumber).toHaveBeenCalledWith();
     expect(mockRunHandlersOnBlock).toHaveBeenCalledTimes(1);
-    expect(mockRunHandlersOnBlock).toHaveBeenCalledWith(latestBlockNumber);
+    expect(mockRunHandlersOnBlock).toHaveBeenCalledWith(
+      latestBlockNumber,
+      mockNetworkId
+    );
     expect(mockSleep).toHaveBeenCalledTimes(0);
     expect(mockGetSubscriptionAlerts).toHaveBeenCalledTimes(0);
     expect(mockRunHandlersOnAlert).toHaveBeenCalledTimes(0);
@@ -101,20 +103,32 @@ describe("runLive", () => {
       .mockReturnValueOnce(true)
       .mockReturnValueOnce(true)
       .mockReturnValueOnce(false);
-    mockEthersProvider.getBlockNumber
+    mockGetLatestBlockNumber
       .mockReturnValueOnce(latestBlockNumber)
       .mockReturnValueOnce(latestBlockNumber + 3);
-    mockEthersProvider.getNetwork.mockReturnValueOnce(blockChainNetwork);
+    mockGetNetworkId.mockReturnValueOnce(mockNetworkId);
 
     await runLive(mockShouldContinuePolling);
 
-    expect(mockEthersProvider.getBlockNumber).toHaveBeenCalledTimes(2);
-    expect(mockEthersProvider.getBlockNumber).toHaveBeenCalledWith();
+    expect(mockGetLatestBlockNumber).toHaveBeenCalledTimes(2);
+    expect(mockGetLatestBlockNumber).toHaveBeenCalledWith();
     expect(mockRunHandlersOnBlock).toHaveBeenCalledTimes(4);
-    expect(mockRunHandlersOnBlock).toHaveBeenCalledWith(latestBlockNumber);
-    expect(mockRunHandlersOnBlock).toHaveBeenCalledWith(latestBlockNumber + 1);
-    expect(mockRunHandlersOnBlock).toHaveBeenCalledWith(latestBlockNumber + 2);
-    expect(mockRunHandlersOnBlock).toHaveBeenCalledWith(latestBlockNumber + 3);
+    expect(mockRunHandlersOnBlock).toHaveBeenCalledWith(
+      latestBlockNumber,
+      mockNetworkId
+    );
+    expect(mockRunHandlersOnBlock).toHaveBeenCalledWith(
+      latestBlockNumber + 1,
+      mockNetworkId
+    );
+    expect(mockRunHandlersOnBlock).toHaveBeenCalledWith(
+      latestBlockNumber + 2,
+      mockNetworkId
+    );
+    expect(mockRunHandlersOnBlock).toHaveBeenCalledWith(
+      latestBlockNumber + 3,
+      mockNetworkId
+    );
     expect(mockGetSubscriptionAlerts).toHaveBeenCalledTimes(1);
     expect(mockGetSubscriptionAlerts).toHaveBeenCalledWith(
       mockInitializeResponse.alertConfig.subscriptions,
@@ -133,17 +147,20 @@ describe("runLive", () => {
       .mockReturnValueOnce(true)
       .mockReturnValueOnce(true)
       .mockReturnValueOnce(false);
-    mockEthersProvider.getBlockNumber
+    mockGetLatestBlockNumber
       .mockReturnValueOnce(latestBlockNumber)
       .mockReturnValueOnce(latestBlockNumber);
-    mockEthersProvider.getNetwork.mockReturnValueOnce(blockChainNetwork);
+    mockGetNetworkId.mockReturnValueOnce(mockNetworkId);
 
     await runLive(mockShouldContinuePolling);
 
-    expect(mockEthersProvider.getBlockNumber).toHaveBeenCalledTimes(2);
-    expect(mockEthersProvider.getBlockNumber).toHaveBeenCalledWith();
+    expect(mockGetLatestBlockNumber).toHaveBeenCalledTimes(2);
+    expect(mockGetLatestBlockNumber).toHaveBeenCalledWith();
     expect(mockRunHandlersOnBlock).toHaveBeenCalledTimes(1);
-    expect(mockRunHandlersOnBlock).toHaveBeenCalledWith(latestBlockNumber);
+    expect(mockRunHandlersOnBlock).toHaveBeenCalledWith(
+      latestBlockNumber,
+      mockNetworkId
+    );
     expect(mockSleep).toHaveBeenCalledTimes(1);
     expect(mockSleep).toHaveBeenCalledWith(15000);
   });

--- a/cli/commands/run/run.live.ts
+++ b/cli/commands/run/run.live.ts
@@ -1,25 +1,30 @@
-import { providers } from "ethers";
 import { BotSubscription } from "../../../sdk";
 import { assertExists, getBlockChainNetworkConfig } from "../../utils";
 import { GetAgentHandlers } from "../../utils/get.agent.handlers";
 import { GetSubscriptionAlerts } from "../../utils/get.subscription.alerts";
 import { RunHandlersOnAlert } from "../../utils/run.handlers.on.alert";
 import { RunHandlersOnBlock } from "../../utils/run.handlers.on.block";
+import { GetNetworkId } from "../../utils/get.network.id";
+import { GetLatestBlockNumber } from "../../utils/get.latest.block.number";
 
 // runs agent handlers against live blockchain data
 export type RunLive = (shouldContinuePolling?: Function) => Promise<void>;
 
+const ONE_MIN_IN_MS = 60000
+
 export function provideRunLive(
   getAgentHandlers: GetAgentHandlers,
   getSubscriptionAlerts: GetSubscriptionAlerts,
-  ethersProvider: providers.JsonRpcProvider,
+  getNetworkId: GetNetworkId,
+  getLatestBlockNumber: GetLatestBlockNumber,
   runHandlersOnBlock: RunHandlersOnBlock,
   runHandlersOnAlert: RunHandlersOnAlert,
   sleep: (durationMs: number) => Promise<void>
 ): RunLive {
   assertExists(getAgentHandlers, "getAgentHandlers");
   assertExists(getSubscriptionAlerts, "getSubscriptionAlerts");
-  assertExists(ethersProvider, "ethersProvider");
+  assertExists(getNetworkId, "getNetworkId");
+  assertExists(getLatestBlockNumber, "getLatestBlockNumber");
   assertExists(runHandlersOnBlock, "runHandlersOnBlock");
   assertExists(runHandlersOnAlert, "runHandlersOnAlert");
   assertExists(sleep, "sleep");
@@ -37,15 +42,14 @@ export function provideRunLive(
     }
 
     console.log("listening for blockchain data...");
-    const network = await ethersProvider.getNetwork();
-    const { chainId } = network;
-    const { blockTimeInSeconds } = getBlockChainNetworkConfig(chainId);
+    const networkId = await getNetworkId();
+    const { blockTimeInSeconds } = getBlockChainNetworkConfig(networkId);
     let currBlockNumber;
     let lastAlertFetchTimestamp: Date | undefined = undefined;
 
     // poll for latest blocks
     while (shouldContinuePolling()) {
-      const latestBlockNumber = await ethersProvider.getBlockNumber();
+      const latestBlockNumber = await getLatestBlockNumber();
       if (currBlockNumber == undefined) {
         currBlockNumber = latestBlockNumber;
       }
@@ -58,7 +62,7 @@ export function provideRunLive(
         // process new blocks
         while (currBlockNumber <= latestBlockNumber) {
           if (handleBlock || handleTransaction) {
-            await runHandlersOnBlock(currBlockNumber);
+            await runHandlersOnBlock(currBlockNumber, networkId);
           }
           currBlockNumber++;
         }
@@ -67,13 +71,13 @@ export function provideRunLive(
         if (
           handleAlert &&
           (lastAlertFetchTimestamp == undefined ||
-            Date.now() - lastAlertFetchTimestamp.getTime() > 60000)
+            Date.now() - lastAlertFetchTimestamp.getTime() > ONE_MIN_IN_MS)
         ) {
           const queryStartTime = new Date();
           console.log("querying alerts...");
           const alerts = await getSubscriptionAlerts(
             botSubscriptions,
-            lastAlertFetchTimestamp || new Date(Date.now() - 60000)
+            lastAlertFetchTimestamp || new Date(Date.now() - ONE_MIN_IN_MS)
           );
           console.log(`found ${alerts.length} alerts`);
           lastAlertFetchTimestamp = queryStartTime;

--- a/cli/di.container.ts
+++ b/cli/di.container.ts
@@ -263,6 +263,7 @@ export default function configureContainer(args: any = {}) {
       return jsonRpcUrl
     }),
     ethersProvider: asFunction((jsonRpcUrl: string) =>  new ethers.providers.JsonRpcProvider(jsonRpcUrl)).singleton(),
+    ethersProviderSend: asValue((ethersProvider: ethers.providers.JsonRpcProvider) => ethersProvider.send.bind(ethersProvider)),// need to bind() so that "this" is defined
     ethersAgentRegistryProvider: asFunction((agentRegistryJsonRpcUrl: string) => new ethers.providers.JsonRpcProvider(agentRegistryJsonRpcUrl)).singleton(),
 
     ipfsGatewayUrl: asFunction((fortaConfig: FortaConfig) => {

--- a/cli/di.container.ts
+++ b/cli/di.container.ts
@@ -58,6 +58,8 @@ import { provideRunSequence } from './commands/run/run.sequence'
 import { provideRunHandlersOnAlert } from './utils/run.handlers.on.alert'
 import provideGetAlert from './utils/get.alert'
 import { provideGetSubscriptionAlerts } from './utils/get.subscription.alerts'
+import provideGetLatestBlockNumber from './utils/get.latest.block.number'
+import provideWithRetry from './utils/with.retry'
 
 export default function configureContainer(args: any = {}) {
   const container = createContainer({ injectionMode: InjectionMode.CLASSIC });
@@ -204,7 +206,9 @@ export default function configureContainer(args: any = {}) {
     initKeyfile: asFunction(provideInitKeyfile),
     initConfig: asFunction(provideInitConfig),
 
+    withRetry: asFunction(provideWithRetry),
     getNetworkId: asFunction(provideGetNetworkId),
+    getLatestBlockNumber: asFunction(provideGetLatestBlockNumber),
     getBlockWithTransactions: asFunction(provideGetBlockWithTransactions),
     getTransactionReceipt: asFunction(provideGetTransactionReceipt),
     getLogsForBlock: asFunction(provideGetLogsForBlock),

--- a/cli/di.container.ts
+++ b/cli/di.container.ts
@@ -263,7 +263,7 @@ export default function configureContainer(args: any = {}) {
       return jsonRpcUrl
     }),
     ethersProvider: asFunction((jsonRpcUrl: string) =>  new ethers.providers.JsonRpcProvider(jsonRpcUrl)).singleton(),
-    ethersProviderSend: asValue((ethersProvider: ethers.providers.JsonRpcProvider) => ethersProvider.send.bind(ethersProvider)),// need to bind() so that "this" is defined
+    ethersProviderSend: asFunction((ethersProvider: ethers.providers.JsonRpcProvider) => ethersProvider.send.bind(ethersProvider)),// need to bind() so that "this" is defined
     ethersAgentRegistryProvider: asFunction((agentRegistryJsonRpcUrl: string) => new ethers.providers.JsonRpcProvider(agentRegistryJsonRpcUrl)).singleton(),
 
     ipfsGatewayUrl: asFunction((fortaConfig: FortaConfig) => {

--- a/cli/utils/get.latest.block.number.spec.ts
+++ b/cli/utils/get.latest.block.number.spec.ts
@@ -1,0 +1,30 @@
+import provideGetLatestBlockNumber, {
+  GetLatestBlockNumber,
+} from "./get.latest.block.number";
+
+describe("getLatestBlockNumber", () => {
+  let getLatestBlockNumber: GetLatestBlockNumber;
+  const mockWithRetry = jest.fn();
+  const mockEthersProviderSend = jest.fn();
+
+  beforeAll(() => {
+    getLatestBlockNumber = provideGetLatestBlockNumber(
+      mockWithRetry,
+      mockEthersProviderSend
+    );
+  });
+
+  it("invokes the eth_blockNumber jsonrpc method and returns block number", async () => {
+    const mockBlockNumber = "0x3039";
+    mockWithRetry.mockReturnValueOnce(mockBlockNumber);
+
+    const blockNumber = await getLatestBlockNumber();
+
+    expect(blockNumber).toEqual(12345); // should convert hex string to decimal number
+    expect(mockWithRetry).toHaveBeenCalledTimes(1);
+    expect(mockWithRetry).toHaveBeenCalledWith(mockEthersProviderSend, [
+      "eth_blockNumber",
+      [],
+    ]);
+  });
+});

--- a/cli/utils/get.latest.block.number.ts
+++ b/cli/utils/get.latest.block.number.ts
@@ -1,4 +1,3 @@
-import { providers } from "ethers";
 import { assertExists } from ".";
 import { WithRetry } from "./with.retry";
 
@@ -7,16 +6,16 @@ export type GetLatestBlockNumber = () => Promise<number>;
 
 export default function provideGetLatestBlockNumber(
   withRetry: WithRetry,
-  ethersProvider: providers.JsonRpcProvider
+  ethersProviderSend: (method: string, params: any[]) => Promise<any>
 ) {
   assertExists(withRetry, "withRetry");
-  assertExists(ethersProvider, "ethersProvider");
+  assertExists(ethersProviderSend, "ethersProviderSend");
 
   return async function getLatestBlockNumber() {
-    const blockNumberHex: string = await withRetry(
-      ethersProvider.send.bind(ethersProvider), // need to bind() so that "this" is defined
-      ["eth_blockNumber", []]
-    );
+    const blockNumberHex: string = await withRetry(ethersProviderSend, [
+      "eth_blockNumber",
+      [],
+    ]);
     return parseInt(blockNumberHex);
   };
 }

--- a/cli/utils/get.latest.block.number.ts
+++ b/cli/utils/get.latest.block.number.ts
@@ -2,21 +2,21 @@ import { providers } from "ethers";
 import { assertExists } from ".";
 import { WithRetry } from "./with.retry";
 
-// returns the network/chain id as reported by the "net_version" json-rpc method
-export type GetNetworkId = () => Promise<number>;
+// returns the latest block number as reported by the "eth_blockNumber" json-rpc method
+export type GetLatestBlockNumber = () => Promise<number>;
 
-export default function provideGetNetworkId(
+export default function provideGetLatestBlockNumber(
   withRetry: WithRetry,
   ethersProvider: providers.JsonRpcProvider
 ) {
   assertExists(withRetry, "withRetry");
   assertExists(ethersProvider, "ethersProvider");
 
-  return async function getNetworkId() {
-    const networkId: string = await withRetry(
+  return async function getLatestBlockNumber() {
+    const blockNumberHex: string = await withRetry(
       ethersProvider.send.bind(ethersProvider), // need to bind() so that "this" is defined
-      ["net_version", []]
+      ["eth_blockNumber", []]
     );
-    return parseInt(networkId);
+    return parseInt(blockNumberHex);
   };
 }

--- a/cli/utils/get.network.id.spec.ts
+++ b/cli/utils/get.network.id.spec.ts
@@ -1,23 +1,25 @@
-import provideGetNetworkId, { GetNetworkId } from "./get.network.id"
+import provideGetNetworkId, { GetNetworkId } from "./get.network.id";
 
 describe("getNetworkId", () => {
-  let getNetworkId: GetNetworkId
-  const mockEthersProvider = {
-    send: jest.fn()
-  } as any
+  let getNetworkId: GetNetworkId;
+  const mockWithRetry = jest.fn();
+  const mockEthersProviderSend = jest.fn();
 
   beforeAll(() => {
-    getNetworkId = provideGetNetworkId(mockEthersProvider)
-  })
+    getNetworkId = provideGetNetworkId(mockWithRetry, mockEthersProviderSend);
+  });
 
   it("invokes the net_version jsonrpc method and returns network id", async () => {
-    const mockNetworkId = 5
-    mockEthersProvider.send.mockReturnValueOnce(mockNetworkId)
+    const mockNetworkId = "0xf";
+    mockWithRetry.mockReturnValueOnce(mockNetworkId);
 
-    const networkId = await getNetworkId()
+    const networkId = await getNetworkId();
 
-    expect(networkId).toEqual(mockNetworkId)
-    expect(mockEthersProvider.send).toHaveBeenCalledTimes(1)
-    expect(mockEthersProvider.send).toHaveBeenCalledWith("net_version", [])
-  })
-})
+    expect(networkId).toEqual(15);
+    expect(mockWithRetry).toHaveBeenCalledTimes(1);
+    expect(mockWithRetry).toHaveBeenCalledWith(mockEthersProviderSend, [
+      "net_version",
+      [],
+    ]);
+  });
+});

--- a/cli/utils/get.network.id.ts
+++ b/cli/utils/get.network.id.ts
@@ -1,4 +1,3 @@
-import { providers } from "ethers";
 import { assertExists } from ".";
 import { WithRetry } from "./with.retry";
 
@@ -7,16 +6,16 @@ export type GetNetworkId = () => Promise<number>;
 
 export default function provideGetNetworkId(
   withRetry: WithRetry,
-  ethersProvider: providers.JsonRpcProvider
+  ethersProviderSend: (method: string, params: any[]) => Promise<any>
 ) {
   assertExists(withRetry, "withRetry");
-  assertExists(ethersProvider, "ethersProvider");
+  assertExists(ethersProviderSend, "ethersProviderSend");
 
   return async function getNetworkId() {
-    const networkId: string = await withRetry(
-      ethersProvider.send.bind(ethersProvider), // need to bind() so that "this" is defined
-      ["net_version", []]
-    );
+    const networkId: string = await withRetry(ethersProviderSend, [
+      "net_version",
+      [],
+    ]);
     return parseInt(networkId);
   };
 }

--- a/cli/utils/run.handlers.on.block.spec.ts
+++ b/cli/utils/run.handlers.on.block.spec.ts
@@ -47,20 +47,20 @@ describe("runHandlersOnBlock", () => {
     const txFindings = getFindingsArray(1, 1)
     const mockHandleBlock = jest.fn().mockReturnValue(blockFindings)
     const mockHandleTransaction = jest.fn().mockReturnValue(txFindings)
-    mockGetAgentHandlers.mockReturnValueOnce({ handleBlock: mockHandleBlock, handleTransaction: mockHandleTransaction })
+    mockGetAgentHandlers.mockReturnValue({ handleBlock: mockHandleBlock, handleTransaction: mockHandleTransaction })
     const mockNetworkId = 1
-    mockGetNetworkId.mockReturnValueOnce(mockNetworkId)
+    mockGetNetworkId.mockReturnValue(mockNetworkId)
     const mockTransaction = { hash: mockTxHash }
     const mockBlock = { hash: mockBlockHash, number: 7, transactions: [mockTransaction, mockTransaction] }
-    mockGetBlockWithTransactions.mockReturnValueOnce(mockBlock)
+    mockGetBlockWithTransactions.mockReturnValue(mockBlock)
     const mockBlockEvent = {}
-    mockCreateBlockEvent.mockReturnValueOnce(mockBlockEvent)
+    mockCreateBlockEvent.mockReturnValue(mockBlockEvent)
     const mockTrace = { transactionHash: mockTxHash, some: 'trace' }
-    mockGetTraceData.mockReturnValueOnce([mockTrace])
+    mockGetTraceData.mockReturnValue([mockTrace])
     const mockLog = { transactionHash: mockTxHash, some: 'log' }
-    mockGetLogsForBlock.mockReturnValueOnce([mockLog])
+    mockGetLogsForBlock.mockReturnValue([mockLog])
     const mockTxEvent = {}
-    mockCreateTransactionEvent.mockReturnValueOnce(mockTxEvent)
+    mockCreateTransactionEvent.mockReturnValue(mockTxEvent)
 
     const findings = await runHandlersOnBlock(mockBlockHash)
 
@@ -83,9 +83,14 @@ describe("runHandlersOnBlock", () => {
     expect(mockCreateTransactionEvent).toHaveBeenCalledWith(mockTransaction, mockBlock, mockNetworkId, [mockTrace], [mockLog])
     expect(mockHandleTransaction).toHaveBeenCalledTimes(2)
     expect(mockHandleTransaction).toHaveBeenCalledWith(mockTxEvent)
+
+    // if invoked with a network id parameter, should not invoke getNetworkId
+    mockGetNetworkId.mockReset()
+    await runHandlersOnBlock(mockBlockHash, mockNetworkId)
+    expect(mockGetNetworkId).toHaveBeenCalledTimes(0)
   })
 
-  it("throws an error if more than 10 findings when handling a block", async () => {
+  it("throws an error if more than 50 findings when handling a block", async () => {
     const findings = getFindingsArray(51, 10)
     try {
 

--- a/cli/utils/run.handlers.on.block.ts
+++ b/cli/utils/run.handlers.on.block.ts
@@ -7,7 +7,7 @@ import { GetBlockWithTransactions } from "./get.block.with.transactions";
 import { JsonRpcLog } from "./get.transaction.receipt";
 import { GetLogsForBlock } from "./get.logs.for.block";
 
-export type RunHandlersOnBlock = (blockHashOrNumber: string | number) => Promise<Finding[]>
+export type RunHandlersOnBlock = (blockHashOrNumber: string | number, networkId?: number) => Promise<Finding[]>
 
 export function provideRunHandlersOnBlock(
   getAgentHandlers: GetAgentHandlers,
@@ -26,7 +26,7 @@ export function provideRunHandlersOnBlock(
   assertExists(createBlockEvent, 'createBlockEvent')
   assertExists(createTransactionEvent, 'createTransactionEvent')
 
-  return async function runHandlersOnBlock(blockHashOrNumber: string | number) {
+  return async function runHandlersOnBlock(blockHashOrNumber: string | number, networkIdArg?: number) {
     const { handleBlock, handleTransaction } = await getAgentHandlers()
     if (!handleBlock && !handleTransaction) {
       throw new Error("no block/transaction handler found")
@@ -34,7 +34,7 @@ export function provideRunHandlersOnBlock(
 
     console.log(`fetching block ${blockHashOrNumber}...`)
     const [networkId, block] = await Promise.all([
-      getNetworkId(),
+      networkIdArg != undefined ? Promise.resolve(networkIdArg) : getNetworkId(),
       getBlockWithTransactions(blockHashOrNumber)
     ]) 
 

--- a/cli/utils/with.retry.spec.ts
+++ b/cli/utils/with.retry.spec.ts
@@ -1,0 +1,48 @@
+import provideWithRetry, { WithRetry } from "./with.retry";
+
+describe("withRetry", () => {
+  let withRetry: WithRetry;
+  const mockSleep = jest.fn();
+  const mockFunc = jest.fn();
+  const mockResponseValue = "some value";
+
+  beforeAll(() => {
+    withRetry = provideWithRetry(mockSleep);
+  });
+
+  beforeEach(() => {
+    mockSleep.mockReset();
+    mockFunc.mockReset();
+  });
+
+  it("throws error if given function fails more than 3 times", async () => {
+    mockFunc.mockRejectedValue("error");
+
+    try {
+      await withRetry(mockFunc, [1, "abc", []]);
+    } catch (e) {
+      expect(e).toBe("error");
+      expect(mockFunc).toHaveBeenCalledTimes(3);
+      expect(mockFunc).toHaveBeenCalledWith(1, "abc", []);
+      expect(mockSleep).toHaveBeenCalledTimes(2);
+      expect(mockSleep).toHaveBeenNthCalledWith(1, 1000);
+      expect(mockSleep).toHaveBeenNthCalledWith(2, 2000);
+    }
+  });
+
+  it("invokes the given function up to max 3 times and returns its response", async () => {
+    mockFunc
+      .mockRejectedValueOnce("error")
+      .mockRejectedValueOnce("error")
+      .mockReturnValueOnce(mockResponseValue);
+
+    const response = await withRetry(mockFunc, [1, "abc", []]);
+
+    expect(response).toBe(mockResponseValue);
+    expect(mockFunc).toHaveBeenCalledTimes(3);
+    expect(mockFunc).toHaveBeenCalledWith(1, "abc", []);
+    expect(mockSleep).toHaveBeenCalledTimes(2);
+    expect(mockSleep).toHaveBeenNthCalledWith(1, 1000);
+    expect(mockSleep).toHaveBeenNthCalledWith(2, 2000);
+  });
+});

--- a/cli/utils/with.retry.ts
+++ b/cli/utils/with.retry.ts
@@ -1,0 +1,32 @@
+import { assertExists } from ".";
+
+// execute a function with args up to MAX_RETRIES number of times with increasing backoff between each retry
+// adapted from https://tusharf5.com/posts/type-safe-retry-function-in-typescript/
+export type WithRetry = <T extends (...arg0: any[]) => any>(
+  func: T,
+  args: Parameters<T>,
+  attemptNumber?: number
+) => Promise<Awaited<ReturnType<T>>>;
+
+const MAX_RETRIES = 3;
+
+export default function provideWithRetry(
+  sleep: (durationMs: number) => Promise<void>
+): WithRetry {
+  assertExists(sleep, "sleep");
+
+  return async function withRetry<T extends (...arg0: any[]) => any>(
+    func: T,
+    args: Parameters<T>,
+    attemptNumber: number = 1
+  ): Promise<Awaited<ReturnType<T>>> {
+    try {
+      const result = await func(...args);
+      return result;
+    } catch (e) {
+      if (attemptNumber >= MAX_RETRIES) throw e;
+      await sleep(1000 * attemptNumber); // wait a bit before trying again
+      return withRetry(func, args, attemptNumber + 1);
+    }
+  };
+}


### PR DESCRIPTION
adding retry logic for `runLive` CLI command. a user reported crashes due to failed RPC calls for networkId and blockNumber when running locally for an extended period of time