### PR TITLE
feat: created TransactionEvent.filterLog like static function

### DIFF
--- a/sdk/transaction.event.ts
+++ b/sdk/transaction.event.ts
@@ -66,36 +66,7 @@ export class TransactionEvent {
     eventAbi: string | string[],
     contractAddress?: string | string[]
   ): LogDescription[] {
-    eventAbi = _.isArray(eventAbi) ? eventAbi : [eventAbi];
-    let logs = this.logs;
-    // filter logs by contract address, if provided
-    if (contractAddress) {
-      contractAddress = _.isArray(contractAddress)
-        ? contractAddress
-        : [contractAddress];
-      const contractAddressMap: { [address: string]: boolean } = {};
-      contractAddress.forEach((address) => {
-        contractAddressMap[address.toLowerCase()] = true;
-      });
-      logs = logs.filter(
-        (log) => contractAddressMap[log.address.toLowerCase()]
-      );
-    }
-    // parse logs
-    const results: LogDescription[] = [];
-    const iface = new ethers.utils.Interface(eventAbi);
-    for (const log of logs) {
-      try {
-        const parsedLog = iface.parseLog(log);
-        results.push(
-          Object.assign(parsedLog, {
-            address: log.address,
-            logIndex: log.logIndex,
-          })
-        );
-      } catch (e) {} // TODO see if theres a better way to handle 'no matching event' error
-    }
-    return results;
+    return TransactionEvent.filterLog(this.logs, eventAbi, contractAddress)
   }
 
   filterFunction(
@@ -141,5 +112,39 @@ export class TransactionEvent {
       } catch (e) {} // TODO see if theres a better way to handle 'no matching function' error
     }
     return results;
+  }
+
+  static filterLog(
+      logs: Log[],
+      eventAbi: string | string[],
+      contractAddress?: string | string[],
+  ): LogDescription[] {
+    eventAbi = _.isArray(eventAbi) ? eventAbi : [eventAbi]
+    // filter logs by contract address, if provided
+    if (contractAddress) {
+      contractAddress = _.isArray(contractAddress)
+          ? contractAddress
+          : [contractAddress]
+      const contractAddressMap: { [address: string]: boolean } = {}
+      contractAddress.forEach((address) => {
+        contractAddressMap[address.toLowerCase()] = true
+      })
+      logs = logs.filter((log) => contractAddressMap[log.address.toLowerCase()])
+    }
+    // parse logs
+    const results: LogDescription[] = []
+    const iface = new ethers.utils.Interface(eventAbi)
+    for (const log of logs) {
+      try {
+        const parsedLog = iface.parseLog(log)
+        results.push(
+            Object.assign(parsedLog, {
+              address: log.address,
+              logIndex: log.logIndex,
+            }),
+        )
+      } catch (e) {} // TODO see if theres a better way to handle 'no matching function' errorheres a better way to handle 'no matching event' error
+    }
+    return results
   }
 }


### PR DESCRIPTION
Subject: Adding Static `filterLog` Method to TransactionEvent Class

---
This pull request addresses the need for a more convenient way to utilize the `filterLog` method in the `TransactionEvent` class. Currently, to use this method, developers are required to create an instance of the `TransactionEvent` class with a comprehensive set of parameters.

To enhance usability, I've introduced a static method `filterLog` within the `TransactionEvent` class. This new method requires only the essential `logs` field, along with the `eventAbi` and optional `contractAddress` parameters. This allows developers to filter logs more efficiently without the need to instantiate the entire `TransactionEvent` class.

Here's a brief overview of the changes:

### Changes Proposed:

#### Added Static `filterLog` Method

```typescript
class TransactionEvent {
  // Existing code...

  static filterLog(
    logs: Log[],
    eventAbi: string | string[],
    contractAddress?: string | string[],
  ): LogDescription[] {
    // Implementation details...
  }
}
```